### PR TITLE
[FIX] : Request DTO 적절하지 않은 어노테이션 삭제

### DIFF
--- a/src/main/java/com/weiver/applicant/domain/Applicant.java
+++ b/src/main/java/com/weiver/applicant/domain/Applicant.java
@@ -68,7 +68,7 @@ public class Applicant extends BaseTimeEntity {
             this.address = updateDTO.address();
         }
         if(updateDTO.birthday() != null) {
-            this.birthday = LocalDate.parse(updateDTO.birthday());
+            this.birthday = updateDTO.birthday();
         }
     }
 }

--- a/src/main/java/com/weiver/applicant/domain/Award.java
+++ b/src/main/java/com/weiver/applicant/domain/Award.java
@@ -40,7 +40,7 @@ public class Award extends BaseTimeEntity {
      * */
     public void updateAward(AwardUpdateDetailDTO updateDTO){
         if(updateDTO.awardDate() != null) {
-            this.awardDate = LocalDate.parse(updateDTO.awardDate());
+            this.awardDate = updateDTO.awardDate();
         }
         if(updateDTO.awardName() != null) {
             this.awardName = updateDTO.awardName();

--- a/src/main/java/com/weiver/applicant/domain/Certificate.java
+++ b/src/main/java/com/weiver/applicant/domain/Certificate.java
@@ -45,7 +45,7 @@ public class Certificate extends BaseTimeEntity {
             this.issuer = updateDTO.issuer();
         }
         if(updateDTO.acquisitionDate() != null) {
-            this.acquisitionDate = LocalDate.parse(updateDTO.acquisitionDate());
+            this.acquisitionDate = updateDTO.acquisitionDate();
         }
     }
 }

--- a/src/main/java/com/weiver/applicant/domain/Education.java
+++ b/src/main/java/com/weiver/applicant/domain/Education.java
@@ -68,10 +68,10 @@ public class Education extends BaseTimeEntity {
             this.gpa = new BigDecimal(updateDTO.gpa());
         }
         if(updateDTO.startDate() != null) {
-            this.startDate = YearMonth.parse(updateDTO.startDate());
+            this.startDate = updateDTO.startDate();
         }
         if(updateDTO.endDate() != null) {
-            this.endDate = YearMonth.parse(updateDTO.endDate());
+            this.endDate = updateDTO.endDate();
         }
         if(updateDTO.status() != null) {
             this.status = Status.valueOf(updateDTO.status());

--- a/src/main/java/com/weiver/applicant/domain/WorkExperience.java
+++ b/src/main/java/com/weiver/applicant/domain/WorkExperience.java
@@ -57,10 +57,10 @@ public class WorkExperience extends BaseTimeEntity {
             this.companyName = updateDTO.companyName();
         }
         if(updateDTO.startDate() != null) {
-            this.startDate = LocalDate.parse(updateDTO.startDate());
+            this.startDate = updateDTO.startDate();
         }
         if(updateDTO.endDate() != null) {
-            this.endDate = LocalDate.parse(updateDTO.endDate());
+            this.endDate = updateDTO.endDate();
         }
         if(updateDTO.employmentType() != null) {
             this.employmentType = EmploymentType.valueOf(updateDTO.employmentType());

--- a/src/main/java/com/weiver/applicant/dto/request/post/ApplicantInfoRequestDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/post/ApplicantInfoRequestDTO.java
@@ -22,7 +22,6 @@ public record ApplicantInfoRequestDTO(
     @NotBlank(message = "주소는 필수 입력값입니다.")
     String address,
     @NotBlank(message = "생년월일은 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "생년월일은 YYYY-MM-DD 형식이어야 합니다.")
     LocalDate birthday){
     public Applicant toEntity() {
 

--- a/src/main/java/com/weiver/applicant/dto/request/post/AwardDetailDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/post/AwardDetailDTO.java
@@ -4,13 +4,11 @@ package com.weiver.applicant.dto.request.post;
 import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.domain.Award;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDate;
 
 public record AwardDetailDTO (
     @NotBlank(message = "취득 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "취득 날짜는 YYYY-MM-DD 형식이어야 합니다.")
     LocalDate awardDate,
     @NotBlank(message = "수상 이름은 필수 입력값입니다.")
     String awardName,

--- a/src/main/java/com/weiver/applicant/dto/request/post/CertificateDetailDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/post/CertificateDetailDTO.java
@@ -4,13 +4,11 @@ package com.weiver.applicant.dto.request.post;
 import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.domain.Certificate;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDate;
 
 public record CertificateDetailDTO (
     @NotBlank(message = "취득 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "취득 날짜는 YYYY-MM-DD 형식이어야 합니다.")
     LocalDate acquisitionDate,
     @NotBlank(message = "자격증 이름은 필수 입력값입니다.")
     String certificateName,

--- a/src/main/java/com/weiver/applicant/dto/request/post/EducationDetailDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/post/EducationDetailDTO.java
@@ -6,7 +6,6 @@ import com.weiver.applicant.type.Degree;
 import com.weiver.applicant.type.Status;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -23,10 +22,8 @@ public record EducationDetailDTO (
     @NotNull(message = "학점은 필수 입력값입니다.")
     Double gpa,
     @NotBlank(message = "입학 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "입학 날짜는 YYYY-MM 형식이어야 합니다.")
     YearMonth startDate,
     @NotBlank(message = "졸업 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "졸업 날짜는 YYYY-MM 형식이어야 합니다.")
     YearMonth endDate,
     @NotBlank(message = "학력 상태는 필수 입력값입니다.")
     String status){

--- a/src/main/java/com/weiver/applicant/dto/request/post/WorkExperienceDetailDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/post/WorkExperienceDetailDTO.java
@@ -5,7 +5,6 @@ import com.weiver.applicant.domain.WorkExperience;
 import com.weiver.applicant.type.EmploymentType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDate;
 
@@ -13,9 +12,7 @@ public record WorkExperienceDetailDTO (
     @NotBlank(message = "회사명은 필수입니다.")
     String companyName,
     @NotBlank(message = "입사 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "입사 날짜는 YYYY-MM-DD 형식이어야 합니다.")
     LocalDate startDate,
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "퇴사 날짜는 YYYY-MM-DD 형식이어야 합니다.")
     LocalDate endDate,
     @NotBlank(message = "경력 형태는 필수 입력값입니다.")
     String employmentType,

--- a/src/main/java/com/weiver/applicant/dto/request/put/ApplicantInfoUpdateRequestDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/put/ApplicantInfoUpdateRequestDTO.java
@@ -23,5 +23,4 @@ public record ApplicantInfoUpdateRequestDTO(
         @NotBlank(message = "주소는 필수 입력값입니다.")
         String address,
         @NotBlank(message = "생년월일은 필수 입력값입니다.")
-        @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "생년월일은 YYYY-MM-DD 형식이어야 합니다.")
         LocalDate birthday){}

--- a/src/main/java/com/weiver/applicant/dto/request/put/AwardUpdateDetailDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/put/AwardUpdateDetailDTO.java
@@ -3,7 +3,6 @@ package com.weiver.applicant.dto.request.put;
 import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.domain.Award;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDate;
 
@@ -15,7 +14,6 @@ import java.time.LocalDate;
 public record AwardUpdateDetailDTO(
     Long awardId,
     @NotBlank(message = "취득 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "취득 날짜는 YYYY-MM-DD 형식이어야 합니다.")
     LocalDate awardDate,
     @NotBlank(message = "수상 이름은 필수 입력값입니다.")
     String awardName,

--- a/src/main/java/com/weiver/applicant/dto/request/put/CertificateUpdateDetailDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/put/CertificateUpdateDetailDTO.java
@@ -4,14 +4,12 @@ package com.weiver.applicant.dto.request.put;
 import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.domain.Certificate;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDate;
 
 public record CertificateUpdateDetailDTO(
     Long certificateId,
     @NotBlank(message = "취득 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "취득 날짜는 YYYY-MM-DD 형식이어야 합니다.")
     LocalDate acquisitionDate,
     @NotBlank(message = "자격증 이름은 필수 입력값입니다.")
     String certificateName,

--- a/src/main/java/com/weiver/applicant/dto/request/put/EducationUpdateDetailDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/put/EducationUpdateDetailDTO.java
@@ -6,10 +6,8 @@ import com.weiver.applicant.type.Degree;
 import com.weiver.applicant.type.Status;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.YearMonth;
 
 public record EducationUpdateDetailDTO(
@@ -23,10 +21,8 @@ public record EducationUpdateDetailDTO(
     @NotNull(message = "학점은 필수 입력값입니다.")
     Double gpa,
     @NotBlank(message = "입학 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "입학 날짜는 YYYY-MM 형식이어야 합니다.")
     YearMonth startDate,
     @NotBlank(message = "졸업 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "졸업 날짜는 YYYY-MM 형식이어야 합니다.")
     YearMonth endDate,
     @NotBlank(message = "학력 상태는 필수 입력값입니다.")
     String status){

--- a/src/main/java/com/weiver/applicant/dto/request/put/WorkExperienceUpdateDetailDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/put/WorkExperienceUpdateDetailDTO.java
@@ -5,7 +5,6 @@ import com.weiver.applicant.domain.WorkExperience;
 import com.weiver.applicant.type.EmploymentType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDate;
 
@@ -14,9 +13,7 @@ public record WorkExperienceUpdateDetailDTO(
     @NotBlank(message = "회사명은 필수입니다.")
     String companyName,
     @NotBlank(message = "재직 날짜는 필수 입력값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "입사 날짜는 YYYY-MM-DD 형식이어야 합니다.")
     LocalDate startDate,
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "퇴직 날짜는 YYYY-MM-DD 형식이어야 합니다.")
     LocalDate endDate,
     @NotBlank(message = "경력 형태는 필수 입력값입니다.")
     String employmentType,

--- a/src/main/java/com/weiver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/weiver/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -189,5 +190,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                     .toList();
         }
         return List.of();
+    }
+
+    // 날짜 형식이 틀리거나(2021-99-33) JSON 파싱이 안 될 때 발생하는 예외 처리
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        return ResponseEntity
+                .badRequest()
+                .body("날짜 형식이 올바르지 않거나 존재하지 않는 날짜입니다.");
     }
 }

--- a/src/main/java/com/weiver/jobposting/dto/request/JobPostingRequestDTO.java
+++ b/src/main/java/com/weiver/jobposting/dto/request/JobPostingRequestDTO.java
@@ -8,9 +8,7 @@ import java.util.List;
 
 public record JobPostingRequestDTO(
         @NotBlank String title,
-        @NotBlank
-        @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "마감 기한은 YYYY-MM-DD 형식이어야 합니다.")
-        LocalDate deadline,
+        @NotBlank LocalDate deadline,
         @NotBlank String jobCategory,
         @NotBlank String detailedJob,
         String jobDescription,


### PR DESCRIPTION
## 📝 PR 설명
LocalDate, YearMonth 와 같은 타입을 @Pattern 어노테이션이 작동이 안됩니다.
적절하지 않은 검증 어노테이션 삭제 작업을 위한 PR 입니다.

## 📝 Summary

다양한 도메인에 있는 RequestDTO 의 LocalDate, LocalDateTime, YearMonth 로 받는 데이터의 검증 어노테이션에 @Pattern 삭제 작업을 했습니다.

추가로 각 도메인의 update 편의 메소드에서  LocalDate, LocalDateTime, YearMonth 타입으로 형변환하는 로직도 제거했습니다.

## 🙏 Question & PR point



## 📣 Related Issue

- close #14 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)