### PR TITLE
[FEATURE] RTR기반 토큰 재발급 구현

### DIFF
--- a/src/main/java/com/weiver/auth/controller/AuthController.java
+++ b/src/main/java/com/weiver/auth/controller/AuthController.java
@@ -1,11 +1,15 @@
 package com.weiver.auth.controller;
 
+import com.weiver.auth.dto.response.ReissueResponseDTO;
 import com.weiver.auth.service.AuthService;
+import com.weiver.auth.service.dto.TokenReissueResult;
 import com.weiver.global.common.ApiResponse;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import com.weiver.global.security.cookie.CookieProvider;
+import com.weiver.global.security.cookie.RefreshTokenCookieResolver;
 import com.weiver.global.security.jwt.BearerTokenResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -24,6 +28,7 @@ public class AuthController {
     private final AuthService authService;
     private final CookieProvider cookieProvider;
     private final BearerTokenResolver bearerTokenResolver;
+    private final RefreshTokenCookieResolver refreshTokenCookieResolver;
 
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
@@ -48,5 +53,31 @@ public class AuthController {
         );
 
         return ResponseEntity.ok(ApiResponse.success("로그아웃에 성공했습니다."));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<ReissueResponseDTO>> reissue(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        String refreshToken = refreshTokenCookieResolver.resolve(request);
+
+        if(refreshToken == null) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        TokenReissueResult tokenReissueResult = authService.reissueToken(refreshToken);
+
+        ResponseCookie refreshTokenCookie = cookieProvider.createRefreshTokenCookie(tokenReissueResult.refreshToken());
+
+        response.addHeader(
+                HttpHeaders.SET_COOKIE,
+                refreshTokenCookie.toString()
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                200,
+                new ReissueResponseDTO(tokenReissueResult.accessToken()),
+                "토큰 재발급에 성공했습니다." ));
     }
 }

--- a/src/main/java/com/weiver/auth/dto/response/ReissueResponseDTO.java
+++ b/src/main/java/com/weiver/auth/dto/response/ReissueResponseDTO.java
@@ -1,0 +1,6 @@
+package com.weiver.auth.dto.response;
+
+public record ReissueResponseDTO(
+        String accessToken
+) {
+}

--- a/src/main/java/com/weiver/auth/service/AuthService.java
+++ b/src/main/java/com/weiver/auth/service/AuthService.java
@@ -1,5 +1,8 @@
 package com.weiver.auth.service;
 
+import com.weiver.auth.service.dto.TokenReissueResult;
+
 public interface AuthService {
     void logout(String accessToken);
+    TokenReissueResult reissueToken(String refreshToken);
 }

--- a/src/main/java/com/weiver/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/weiver/auth/service/AuthServiceImpl.java
@@ -1,9 +1,14 @@
 package com.weiver.auth.service;
 
+import com.weiver.auth.service.dto.TokenReissueResult;
+import com.weiver.auth.validator.AuthUserValidator;
 import com.weiver.global.common.UserRole;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
 import com.weiver.global.security.jwt.JwtTokenProvider;
 import com.weiver.global.security.jwt.repository.BlacklistTokenRepository;
 import com.weiver.global.security.jwt.repository.RefreshTokenRepository;
+import com.weiver.global.security.jwt.type.RefreshTokenRotationResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +19,7 @@ public class AuthServiceImpl implements AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final BlacklistTokenRepository blacklistTokenRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final AuthUserValidator authUserValidator;
 
     @Override
     public void logout(String accessToken) {
@@ -23,6 +29,41 @@ public class AuthServiceImpl implements AuthService {
         long ttlMillis = jwtTokenProvider.getRemainingExpiration(accessToken);
 
         blacklistTokenRepository.save(accessToken, ttlMillis);
-        refreshTokenRepository.deleteByUserId(userRole, userId);
+        refreshTokenRepository.deleteByUserId(userId, userRole);
+    }
+
+    @Override
+    public TokenReissueResult reissueToken(String refreshToken) {
+        if(refreshToken == null || refreshToken.isBlank()) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        jwtTokenProvider.validateRefreshToken(refreshToken);
+
+        Long userId = jwtTokenProvider.getUserId(refreshToken);
+        UserRole userRole = jwtTokenProvider.getRole(refreshToken);
+
+        authUserValidator.validateExist(userId, userRole);
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(userId, userRole);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId, userRole);
+        long refreshTokenTtlMillis = jwtTokenProvider.getRemainingExpiration(refreshToken);
+
+        RefreshTokenRotationResult rotationResult = refreshTokenRepository.rotateIfMatches(
+                userId,
+                userRole,
+                refreshToken,
+                newRefreshToken,
+                refreshTokenTtlMillis
+        );
+
+        return switch (rotationResult) {
+            case ROTATED -> new TokenReissueResult(newAccessToken, newRefreshToken);
+            case NOT_FOUND -> throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+            case MISMATCH, CONCURRENT_MODIFIED -> {
+                refreshTokenRepository.deleteByUserId(userId, userRole);
+                throw new BusinessException(ErrorCode.TOKEN_REUSE_DETECTED);
+            }
+        };
     }
 }

--- a/src/main/java/com/weiver/auth/service/dto/TokenReissueResult.java
+++ b/src/main/java/com/weiver/auth/service/dto/TokenReissueResult.java
@@ -1,0 +1,7 @@
+package com.weiver.auth.service.dto;
+
+public record TokenReissueResult(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/weiver/auth/validator/AuthUserValidator.java
+++ b/src/main/java/com/weiver/auth/validator/AuthUserValidator.java
@@ -1,0 +1,26 @@
+package com.weiver.auth.validator;
+
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.global.common.UserRole;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserValidator {
+
+    private final ApplicantRepository applicantRepository;
+
+    public void validateExist(Long userId, UserRole userRole) {
+        switch (userRole) {
+            case APPLICANT -> {
+                if(!applicantRepository.existsById(userId)) {
+                    throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+                }
+            }
+            // 추후 COMPANY 추가
+        }
+    }
+}

--- a/src/main/java/com/weiver/global/config/SecurityConfig.java
+++ b/src/main/java/com/weiver/global/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/logout").authenticated()
+                        .requestMatchers("/auth/reissue").permitAll()
                         .anyRequest().permitAll()
                 );
 

--- a/src/main/java/com/weiver/global/exception/ErrorCode.java
+++ b/src/main/java/com/weiver/global/exception/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
     UNAUTHORIZED("UNAUTHORIZED", HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     FORBIDDEN("FORBIDDEN", HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     MISSING_COOKIE("MISSING_COOKIE", HttpStatus.BAD_REQUEST, "필수 쿠키가 누락되었습니다."),
+    USER_NOT_FOUND("USER_NOT_FOUNT", HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
 
     // ===================== TOKEN =====================
     TOKEN_EXPIRED("TOKEN_EXPIRED", HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
@@ -15,6 +16,7 @@ public enum ErrorCode {
     BLACKLISTED_TOKEN("BLACKLISTED_TOKEN", HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND("REFRESH_TOKEN_NOT_FOUND", HttpStatus.UNAUTHORIZED, "리프레시 토큰이 존재하지 않습니다."),
     REFRESH_TOKEN_EXPIRED("REFRESH_TOKEN_EXPIRED", HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),
+    TOKEN_REUSE_DETECTED("TOKEN_REUSE_DETECTED", HttpStatus.UNAUTHORIZED, "리프레시 토큰 재사용이 감지되었습니다. 다시 로그인해 주세요."),
 
     // ===================== EMAIL =====================
     EMAIL_ALREADY_EXISTS("EMAIL_ALREADY_EXISTS", HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/src/main/java/com/weiver/global/security/cookie/RefreshTokenCookieResolver.java
+++ b/src/main/java/com/weiver/global/security/cookie/RefreshTokenCookieResolver.java
@@ -1,0 +1,35 @@
+package com.weiver.global.security.cookie;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCookieResolver {
+
+    private final CookieProperties cookieProperties;
+
+    public String resolve(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if(cookies == null) return null;
+
+        String refreshTokenCookieName = cookieProperties.name();
+
+        for (Cookie cookie : cookies) {
+            if(!refreshTokenCookieName.equals(cookie.getName())) continue;
+
+            String refreshToken = cookie.getValue();
+
+            if(refreshToken == null || refreshToken.isBlank()) return null;
+
+            return refreshToken;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/weiver/global/security/cookie/RefreshTokenCookieResolver.java
+++ b/src/main/java/com/weiver/global/security/cookie/RefreshTokenCookieResolver.java
@@ -5,8 +5,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-
 @Component
 @RequiredArgsConstructor
 public class RefreshTokenCookieResolver {

--- a/src/main/java/com/weiver/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/weiver/global/security/jwt/JwtTokenProvider.java
@@ -19,12 +19,33 @@ import java.util.Date;
 @EnableConfigurationProperties(JwtProperties.class)
 public class JwtTokenProvider {
 
+    private final JwtProperties jwtProperties;
     private final SecretKey secretKey;
 
     public JwtTokenProvider(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
         this.secretKey = Keys.hmacShaKeyFor(
                 jwtProperties.secret().getBytes(StandardCharsets.UTF_8)
         );
+    }
+
+    public String createAccessToken(Long userId, UserRole role) {
+        return createToken(userId, role, jwtProperties.accessTokenExpiration());
+    }
+
+    public String createRefreshToken(Long userId, UserRole role) {
+        return createToken(userId, role, jwtProperties.refreshTokenExpiration());
+    }
+
+    public void validateRefreshToken(String token) {
+        try {
+            getClaims(token);
+        } catch (BusinessException e) {
+            if(e.getCode() == ErrorCode.TOKEN_EXPIRED) {
+                throw new BusinessException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+            }
+            throw e;
+        }
     }
 
     public long getRemainingExpiration(String token) {
@@ -45,6 +66,19 @@ public class JwtTokenProvider {
 
     public UserRole getRole(String token) {
         return UserRole.valueOf(getClaims(token).get("role", String.class));
+    }
+
+    private String createToken(Long userId, UserRole role, long expirationMillis) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expirationMillis);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("role", role.name())
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(secretKey)
+                .compact();
     }
 
     private Claims getClaims(String token) {

--- a/src/main/java/com/weiver/global/security/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/weiver/global/security/jwt/repository/RefreshTokenRepository.java
@@ -5,7 +5,6 @@ import com.weiver.global.security.jwt.type.RefreshTokenRotationResult;
 import com.weiver.global.security.util.TokenHashUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
-import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SessionCallback;

--- a/src/main/java/com/weiver/global/security/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/weiver/global/security/jwt/repository/RefreshTokenRepository.java
@@ -1,11 +1,17 @@
 package com.weiver.global.security.jwt.repository;
 
 import com.weiver.global.common.UserRole;
+import com.weiver.global.security.jwt.type.RefreshTokenRotationResult;
 import com.weiver.global.security.util.TokenHashUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -17,36 +23,78 @@ public class RefreshTokenRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void save(UserRole userRole, Long userId, String refreshToken, long ttlMillis) {
+    public RefreshTokenRotationResult rotateIfMatches(
+            Long userId,
+            UserRole userRole,
+            String oldRefreshToken,
+            String newRefreshToken,
+            long ttlMillis
+    ) {
+        String key = generateKey(userId, userRole);
+        String oldHash = TokenHashUtil.sha256(oldRefreshToken);
+        String newHash = TokenHashUtil.sha256(newRefreshToken);
+
+        return redisTemplate.execute(new SessionCallback<>() {
+            @Override
+            public RefreshTokenRotationResult execute(RedisOperations operations) throws DataAccessException {
+                operations.watch(key);
+
+                String savedHash = (String) operations.opsForValue().get(key);
+
+                if(savedHash == null) {
+                    operations.unwatch();
+                    return RefreshTokenRotationResult.NOT_FOUND;
+                }
+
+                if(!savedHash.equals(oldHash)) {
+                    operations.unwatch();
+                    return RefreshTokenRotationResult.MISMATCH;
+                }
+
+                operations.multi();
+                operations.opsForValue().set(key, newHash, ttlMillis, TimeUnit.MILLISECONDS);
+
+                List<Object> execResult = operations.exec();
+
+                if(execResult == null || execResult.isEmpty()) {
+                    return RefreshTokenRotationResult.CONCURRENT_MODIFIED;
+                }
+
+                return RefreshTokenRotationResult.ROTATED;
+            }
+        });
+    }
+
+    public void save(Long userId, UserRole userRole, String refreshToken, long ttlMillis) {
         redisTemplate.opsForValue().set(
-                generateKey(userRole, userId),
+                generateKey(userId, userRole),
                 TokenHashUtil.sha256(refreshToken),
                 ttlMillis,
                 TimeUnit.MILLISECONDS
         );
     }
 
-    public Optional<String> findHashByUserId(UserRole userRole, Long userId) {
+    public Optional<String> findHashByUserId(Long userId, UserRole userRole) {
         return Optional.ofNullable(
-                redisTemplate.opsForValue().get(generateKey(userRole, userId))
+                redisTemplate.opsForValue().get(generateKey(userId, userRole))
         );
     }
 
-    public boolean matches(UserRole userRole, Long userId, String refreshToken) {
-        return findHashByUserId(userRole, userId)
+    public boolean matches(Long userId, UserRole userRole, String refreshToken) {
+        return findHashByUserId(userId, userRole)
                 .map(savedHash -> savedHash.equals(TokenHashUtil.sha256(refreshToken)))
                 .orElse(false);
     }
 
-    public void deleteByUserId(UserRole userRole, Long userId) {
-        redisTemplate.delete(generateKey(userRole, userId));
+    public void deleteByUserId(Long userId, UserRole userRole) {
+        redisTemplate.delete(generateKey(userId, userRole));
     }
 
-    public boolean existsByUserId(UserRole userRole, Long userId) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(generateKey(userRole, userId)));
+    public boolean existsByUserId(Long userId, UserRole userRole) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(generateKey(userId, userRole)));
     }
 
-    private String generateKey(UserRole userRole, Long userId) {
+    private String generateKey(Long userId, UserRole userRole) {
         return REFRESH_TOKEN_PREFIX + userRole.name().toLowerCase() + ":" + userId;
     }
 }

--- a/src/main/java/com/weiver/global/security/jwt/type/RefreshTokenRotationResult.java
+++ b/src/main/java/com/weiver/global/security/jwt/type/RefreshTokenRotationResult.java
@@ -1,0 +1,8 @@
+package com.weiver.global.security.jwt.type;
+
+public enum RefreshTokenRotationResult {
+    ROTATED,
+    NOT_FOUND,
+    MISMATCH,
+    CONCURRENT_MODIFIED // Redis 값을 읽고 교체하려는 사이에 누군가 먼저 Redis 값을 바꿈(동시 요청 상황 시 발생 가능)
+}

--- a/src/test/java/com/weiver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/weiver/domain/auth/controller/AuthControllerTest.java
@@ -5,6 +5,7 @@ import com.weiver.auth.service.AuthService;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import com.weiver.global.security.cookie.CookieProvider;
+import com.weiver.global.security.cookie.RefreshTokenCookieResolver;
 import com.weiver.global.security.jwt.BearerTokenResolver;
 import com.weiver.global.security.jwt.JwtAuthenticationFilter;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +41,8 @@ public class AuthControllerTest {
     private BearerTokenResolver bearerTokenResolver;
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockitoBean
+    private RefreshTokenCookieResolver refreshTokenCookieResolver;
 
     @Test
     @DisplayName("로그아웃 성공 시 AuthService를 호출하고 RefreshToken 쿠키를 만료한다.")

--- a/src/test/java/com/weiver/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/weiver/domain/auth/service/AuthServiceTest.java
@@ -1,12 +1,15 @@
 package com.weiver.domain.auth.service;
 
 import com.weiver.auth.service.AuthServiceImpl;
+import com.weiver.auth.service.dto.TokenReissueResult;
+import com.weiver.auth.validator.AuthUserValidator;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import com.weiver.global.common.UserRole;
 import com.weiver.global.security.jwt.JwtTokenProvider;
 import com.weiver.global.security.jwt.repository.BlacklistTokenRepository;
 import com.weiver.global.security.jwt.repository.RefreshTokenRepository;
+import com.weiver.global.security.jwt.type.RefreshTokenRotationResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -30,6 +34,10 @@ public class AuthServiceTest {
     private BlacklistTokenRepository blacklistTokenRepository;
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private AuthUserValidator authUserValidator;
+
+    // ===================== accessToken =====================
 
     @Test
     @DisplayName("정상 로그아웃 시 AccessToken을 블랙리스트에 등록하고 RefreshToken을 삭제")
@@ -52,7 +60,7 @@ public class AuthServiceTest {
         verify(jwtTokenProvider).getRole(accessToken);
         verify(jwtTokenProvider).getRemainingExpiration(accessToken);
         verify(blacklistTokenRepository).save(accessToken, ttlMillis);
-        verify(refreshTokenRepository).deleteByUserId(userRole, userId);
+        verify(refreshTokenRepository).deleteByUserId(userId, userRole);
     }
 
     @Test
@@ -72,7 +80,7 @@ public class AuthServiceTest {
         verify(jwtTokenProvider, never()).getRole(anyString());
         verify(jwtTokenProvider, never()).getRemainingExpiration(anyString());
         verify(blacklistTokenRepository, never()).save(anyString(), anyLong());
-        verify(refreshTokenRepository, never()).deleteByUserId(any(UserRole.class), anyLong());
+        verify(refreshTokenRepository, never()).deleteByUserId(anyLong(), any(UserRole.class));
     }
 
     @Test
@@ -92,6 +100,124 @@ public class AuthServiceTest {
         verify(jwtTokenProvider, never()).getRole(anyString());
         verify(jwtTokenProvider, never()).getRemainingExpiration(anyString());
         verify(blacklistTokenRepository, never()).save(anyString(), anyLong());
-        verify(refreshTokenRepository, never()).deleteByUserId(any(UserRole.class), anyLong());
+        verify(refreshTokenRepository, never()).deleteByUserId(anyLong(), any(UserRole.class));
+    }
+
+    // ===================== reissueToken =====================
+
+    @Test
+    @DisplayName("refreshToken이 null이면 REFRESH_TOKEN_NOT_FOUND 예외")
+    public void reissueToken_nullToken() {
+        assertThatThrownBy(() -> authService.reissueToken(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.REFRESH_TOKEN_NOT_FOUND.defaultMessage);
+    }
+
+    @Test
+    @DisplayName("refreshToken이 blank이면 REFRESH_TOKEN_NOT_FOUND 예외")
+    public void reissueToken_blankToken() {
+        assertThatThrownBy(() -> authService.reissueToken("   "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.REFRESH_TOKEN_NOT_FOUND.defaultMessage);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공 시 새 accessToken과 refreshToken 반환")
+    public void reissueToken_success() {
+        // given
+        String oldRefreshToken = "old_refresh_token";
+        Long userId = 1L;
+        UserRole userRole = UserRole.APPLICANT;
+        String newAccessToken = "new_access_token";
+        String newRefreshToken = "new_refresh_token";
+        long ttlMillis = 1000L * 60 * 60 * 24 * 7;
+
+        when(jwtTokenProvider.getUserId(oldRefreshToken)).thenReturn(userId);
+        when(jwtTokenProvider.getRole(oldRefreshToken)).thenReturn(userRole);
+        when(jwtTokenProvider.createAccessToken(userId, userRole)).thenReturn(newAccessToken);
+        when(jwtTokenProvider.createRefreshToken(userId, userRole)).thenReturn(newRefreshToken);
+        when(jwtTokenProvider.getRemainingExpiration(oldRefreshToken)).thenReturn(ttlMillis);
+        when(refreshTokenRepository.rotateIfMatches(userId, userRole, oldRefreshToken, newRefreshToken, ttlMillis))
+                .thenReturn(RefreshTokenRotationResult.ROTATED);
+
+        // when
+        TokenReissueResult result = authService.reissueToken(oldRefreshToken);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo(newAccessToken);
+        assertThat(result.refreshToken()).isEqualTo(newRefreshToken);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 토큰 없으면 REFRESH_TOKEN_NOT_FOUND 예외")
+    public void reissueToken_notFound() {
+        // given
+        String refreshToken = "valid_refresh_token";
+        Long userId = 1L;
+        UserRole userRole = UserRole.APPLICANT;
+        long ttlMillis = 1000L * 60 * 60 * 24 * 7;
+
+        when(jwtTokenProvider.getUserId(refreshToken)).thenReturn(userId);
+        when(jwtTokenProvider.getRole(refreshToken)).thenReturn(userRole);
+        when(jwtTokenProvider.createAccessToken(userId, userRole)).thenReturn("new_access_token");
+        when(jwtTokenProvider.createRefreshToken(userId, userRole)).thenReturn("new_refresh_token");
+        when(jwtTokenProvider.getRemainingExpiration(refreshToken)).thenReturn(ttlMillis);
+        when(refreshTokenRepository.rotateIfMatches(userId, userRole, refreshToken, "new_refresh_token", ttlMillis))
+                .thenReturn(RefreshTokenRotationResult.NOT_FOUND);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueToken(refreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.REFRESH_TOKEN_NOT_FOUND.defaultMessage);
+    }
+
+    @Test
+    @DisplayName("토큰 재사용 감지(MISMATCH) 시 기존 토큰 삭제 후 TOKEN_REUSE_DETECTED 예외")
+    public void reissueToken_mismatch() {
+        // given
+        String refreshToken = "reused_refresh_token";
+        Long userId = 1L;
+        UserRole userRole = UserRole.APPLICANT;
+        long ttlMillis = 1000L * 60 * 60 * 24 * 7;
+
+        when(jwtTokenProvider.getUserId(refreshToken)).thenReturn(userId);
+        when(jwtTokenProvider.getRole(refreshToken)).thenReturn(userRole);
+        when(jwtTokenProvider.createAccessToken(userId, userRole)).thenReturn("new_access_token");
+        when(jwtTokenProvider.createRefreshToken(userId, userRole)).thenReturn("new_refresh_token");
+        when(jwtTokenProvider.getRemainingExpiration(refreshToken)).thenReturn(ttlMillis);
+        when(refreshTokenRepository.rotateIfMatches(userId, userRole, refreshToken, "new_refresh_token", ttlMillis))
+                .thenReturn(RefreshTokenRotationResult.MISMATCH);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueToken(refreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.TOKEN_REUSE_DETECTED.defaultMessage);
+
+        verify(refreshTokenRepository).deleteByUserId(userId, userRole);
+    }
+
+    @Test
+    @DisplayName("동시 요청 충돌(CONCURRENT_MODIFIED) 시 기존 토큰 삭제 후 TOKEN_REUSE_DETECTED 예외")
+    public void reissueToken_concurrentModified() {
+        // given
+        String refreshToken = "concurrent_refresh_token";
+        Long userId = 1L;
+        UserRole userRole = UserRole.APPLICANT;
+        long ttlMillis = 1000L * 60 * 60 * 24 * 7;
+
+        when(jwtTokenProvider.getUserId(refreshToken)).thenReturn(userId);
+        when(jwtTokenProvider.getRole(refreshToken)).thenReturn(userRole);
+        when(jwtTokenProvider.createAccessToken(userId, userRole)).thenReturn("new_access_token");
+        when(jwtTokenProvider.createRefreshToken(userId, userRole)).thenReturn("new_refresh_token");
+        when(jwtTokenProvider.getRemainingExpiration(refreshToken)).thenReturn(ttlMillis);
+        when(refreshTokenRepository.rotateIfMatches(userId, userRole, refreshToken, "new_refresh_token", ttlMillis))
+                .thenReturn(RefreshTokenRotationResult.CONCURRENT_MODIFIED);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueToken(refreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.TOKEN_REUSE_DETECTED.defaultMessage);
+
+        verify(refreshTokenRepository).deleteByUserId(userId, userRole);
     }
 }

--- a/src/test/java/com/weiver/global/security/jwt/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/weiver/global/security/jwt/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,112 @@
+package com.weiver.global.security.jwt.repository;
+
+import com.weiver.global.common.UserRole;
+import com.weiver.global.security.jwt.type.RefreshTokenRotationResult;
+import com.weiver.global.security.util.TokenHashUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RefreshTokenRepositoryTest {
+
+    @InjectMocks
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private RedisOperations<String, String> redisOperations;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private static final Long USER_ID = 1L;
+    private static final UserRole USER_ROLE = UserRole.APPLICANT;
+    private static final String KEY = "refresh:applicant:1";
+    private static final String OLD_TOKEN = "old_refresh_token";
+    private static final String NEW_TOKEN = "new_refresh_token";
+    private static final long TTL_MILLIS = 1000L * 60 * 60 * 24 * 7;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.execute(any(SessionCallback.class))).thenAnswer(invocation -> {
+            SessionCallback<RefreshTokenRotationResult> callback = invocation.getArgument(0);
+            return callback.execute(redisOperations);
+        });
+        when(redisOperations.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 토큰이 없으면 NOT_FOUND 반환")
+    public void rotateIfMatches_notFound() {
+        // given
+        when(valueOperations.get(KEY)).thenReturn(null);
+
+        // when
+        RefreshTokenRotationResult result = refreshTokenRepository.rotateIfMatches(
+                USER_ID, USER_ROLE, OLD_TOKEN, NEW_TOKEN, TTL_MILLIS);
+
+        // then
+        assertThat(result).isEqualTo(RefreshTokenRotationResult.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("저장된 해시와 입력 토큰 해시가 다르면 MISMATCH 반환")
+    public void rotateIfMatches_mismatch() {
+        // given
+        when(valueOperations.get(KEY)).thenReturn("different_hash_value");
+
+        // when
+        RefreshTokenRotationResult result = refreshTokenRepository.rotateIfMatches(
+                USER_ID, USER_ROLE, OLD_TOKEN, NEW_TOKEN, TTL_MILLIS);
+
+        // then
+        assertThat(result).isEqualTo(RefreshTokenRotationResult.MISMATCH);
+    }
+
+    @Test
+    @DisplayName("해시 일치 후 WATCH 트랜잭션 성공 시 ROTATED 반환")
+    public void rotateIfMatches_rotated() {
+        // given
+        when(valueOperations.get(KEY)).thenReturn(TokenHashUtil.sha256(OLD_TOKEN));
+        when(redisOperations.exec()).thenReturn(List.of("OK"));
+
+        // when
+        RefreshTokenRotationResult result = refreshTokenRepository.rotateIfMatches(
+                USER_ID, USER_ROLE, OLD_TOKEN, NEW_TOKEN, TTL_MILLIS);
+
+        // then
+        assertThat(result).isEqualTo(RefreshTokenRotationResult.ROTATED);
+    }
+
+    @Test
+    @DisplayName("WATCH 충돌로 exec가 null 반환 시 CONCURRENT_MODIFIED 반환")
+    public void rotateIfMatches_concurrentModified() {
+        // given
+        when(valueOperations.get(KEY)).thenReturn(TokenHashUtil.sha256(OLD_TOKEN));
+        when(redisOperations.exec()).thenReturn(null);
+
+        // when
+        RefreshTokenRotationResult result = refreshTokenRepository.rotateIfMatches(
+                USER_ID, USER_ROLE, OLD_TOKEN, NEW_TOKEN, TTL_MILLIS);
+
+        // then
+        assertThat(result).isEqualTo(RefreshTokenRotationResult.CONCURRENT_MODIFIED);
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->

RefreshToken Rotation 방식의 토큰 재발급 API를 구현합니다. 
쿠키에서 RefreshToken을 읽고, Redis WATCH/MULTI/EXEC를 활용한 낙관적 락으로 동시 요청에 대한 토큰 탈취 감지를 처리합니다.


## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- `POST /auth/reissue` 엔드포인트 추가
- `RefreshTokenCookieResolver`: 요청 쿠키에서 RefreshToken 추출
- `RefreshTokenRepository.rotateIfMatches()`: Redis WATCH/MULTI/EXEC 기반 Refresh Token Rotation
- `AuthUserValidator`: 역할별 유저 존재 여부 검증
- `ErrorCode` 추가: `REFRESH_TOKEN_NOT_FOUND`, `TOKEN_REUSE_DETECTED` 

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
Rotation Result 상태는 다음과 같습니다.
- `ROTATED`: 정상 교체
- `NOT_FOUND`: Redis에 토큰 없음 
- `MISMATCH`: 저장된 해시 불일치 → 기존 토큰 강제 삭제
- `CONCURRENT_MODIFIED`: 동시 요청 충돌 → 기존 토큰 강제 삭제     

Swagger 작업은 Issue 새로 만들어서 작업하겠습니다!

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #13 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)