### PR TITLE
[FEATURE] 구직자 회원 관리 구현

### DIFF
--- a/src/main/java/com/weiver/applicant/domain/Applicant.java
+++ b/src/main/java/com/weiver/applicant/domain/Applicant.java
@@ -33,26 +33,32 @@ public class Applicant extends BaseTimeEntity {
     @Column(name = "role", nullable = false)
     private UserRole role = UserRole.APPLICANT;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name", nullable = true)
     private String name;    // 사용자 이름
 
-    @Column(name = "phone_number", nullable = false)
+    @Column(name = "phone_number", nullable = true)
     private String phoneNumber; // 연락처
 
-    @Column(name = "birthday", columnDefinition = "DATE", nullable = false)
+    @Column(name = "birthday", columnDefinition = "DATE", nullable = true)
     private LocalDate birthday; // 생년월일
 
-    @Column(name = "photo_url", columnDefinition = "TEXT")
+    @Column(name = "photo_url", columnDefinition = "TEXT", nullable = true)
     private String photoUrl;    // s3 프로필 이미지 경로
 
-    @Column(name = "last_screening_at")
+    @Column(name = "last_screening_at", nullable = true)
     private LocalDateTime lastScreeningAt;  // 마지막 분석
 
-    @Column(name = "next_available_screening_at")
+    @Column(name = "next_available_screening_at", nullable = true)
     private LocalDateTime nextAvailableScreeningAt; // 다음 분석 가능 시점
 
-    @Column(name = "address", nullable = false)
+    @Column(name = "address", nullable = true)
     private String address;  // 주소
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    private LocalDateTime deletedAt;
 
     /**
      * 정보 업데이트 편의메소드
@@ -74,5 +80,10 @@ public class Applicant extends BaseTimeEntity {
         if(updateDTO.birthday() != null) {
             this.birthday = updateDTO.birthday();
         }
+    }
+
+    public void withdraw() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/weiver/applicant/domain/ApplicantAgreement.java
+++ b/src/main/java/com/weiver/applicant/domain/ApplicantAgreement.java
@@ -1,0 +1,58 @@
+package com.weiver.applicant.domain;
+
+import com.weiver.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "applicant_agreements")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplicantAgreement extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "applicant_agreement_id")
+    private Long applicantAgreementId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", nullable = false, updatable = true)
+    private Applicant applicant;
+
+    @Column(nullable = false)
+    private boolean termsOfService;
+
+    @Column(nullable = false)
+    private boolean privacyPolicy;
+
+    @Column(nullable = false)
+    private boolean individualMemberTerms;
+
+    @Column(nullable = false)
+    private boolean aiAnalysisConsent;
+
+    @Column(nullable = false)
+    private boolean sensitiveDataConsent;
+
+    @Column(nullable = false)
+    private boolean marketingConsent;
+
+    @Builder
+    private ApplicantAgreement(
+            Applicant applicant,
+            boolean termsOfService,
+            boolean privacyPolicy,
+            boolean individualMemberTerms,
+            boolean aiAnalysisConsent,
+            boolean sensitiveDataConsent,
+            boolean marketingConsent
+    ) {
+        this.applicant = applicant;
+        this.termsOfService = termsOfService;
+        this.privacyPolicy = privacyPolicy;
+        this.individualMemberTerms = individualMemberTerms;
+        this.aiAnalysisConsent = aiAnalysisConsent;
+        this.sensitiveDataConsent = sensitiveDataConsent;
+        this.marketingConsent = marketingConsent;
+    }
+}

--- a/src/main/java/com/weiver/applicant/repository/ApplicantAgreementRepository.java
+++ b/src/main/java/com/weiver/applicant/repository/ApplicantAgreementRepository.java
@@ -1,0 +1,7 @@
+package com.weiver.applicant.repository;
+
+import com.weiver.applicant.domain.ApplicantAgreement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicantAgreementRepository extends JpaRepository<ApplicantAgreement, Long> {
+}

--- a/src/main/java/com/weiver/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/weiver/applicant/repository/ApplicantRepository.java
@@ -8,4 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+    boolean existsByEmail(String email);
+    Optional<Applicant> findByEmailAndDeletedFalse(String email);
+    Optional<Applicant> findByApplicantIdAndDeletedFalse(Long applicantId);
 }

--- a/src/main/java/com/weiver/auth/controller/ApplicantAuthController.java
+++ b/src/main/java/com/weiver/auth/controller/ApplicantAuthController.java
@@ -13,7 +13,6 @@ import com.weiver.global.common.ApiResponse;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import com.weiver.global.security.cookie.CookieProvider;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/weiver/auth/controller/ApplicantAuthController.java
+++ b/src/main/java/com/weiver/auth/controller/ApplicantAuthController.java
@@ -1,0 +1,116 @@
+package com.weiver.auth.controller;
+
+import com.weiver.auth.dto.request.ApplicantEmailSendRequestDTO;
+import com.weiver.auth.dto.request.ApplicantEmailVerifyRequestDTO;
+import com.weiver.auth.dto.request.ApplicantLoginRequestDTO;
+import com.weiver.auth.dto.request.ApplicantSignupRequestDTO;
+import com.weiver.auth.dto.response.ApplicantEmailVerifyResponseDTO;
+import com.weiver.auth.dto.response.ApplicantLoginResponseDTO;
+import com.weiver.auth.dto.response.ApplicantSignupResponseDTO;
+import com.weiver.auth.service.ApplicantAuthService;
+import com.weiver.auth.service.dto.ApplicantLoginResult;
+import com.weiver.global.common.ApiResponse;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import com.weiver.global.security.cookie.CookieProvider;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/auth/applicants")
+@RequiredArgsConstructor
+public class ApplicantAuthController {
+
+    private final ApplicantAuthService applicantAuthService;
+    private final CookieProvider cookieProvider;
+
+    @PostMapping("/email/send")
+    public ResponseEntity<ApiResponse<Void>> sendEmailCode(
+            @RequestBody
+            @Valid
+            ApplicantEmailSendRequestDTO requestDTO
+    ) {
+        applicantAuthService.sendEmailCode(requestDTO);
+
+        return ResponseEntity.ok(ApiResponse.success(200, null, "이메일 인증번호 전송에 성공했습니다."));
+    }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<ApiResponse<ApplicantEmailVerifyResponseDTO>> verifyEmailCode(
+            @RequestBody
+            @Valid
+            ApplicantEmailVerifyRequestDTO requestDTO
+    ) {
+        ApplicantEmailVerifyResponseDTO responseDTO = applicantAuthService.verifyEmailCode(requestDTO);
+
+        return ResponseEntity.ok(ApiResponse.success(200, responseDTO, "이메일 인증번호 확인에 성공했습니다."));
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<ApplicantSignupResponseDTO>> signup(
+            @RequestBody
+            @Valid
+            ApplicantSignupRequestDTO requestDTO
+    ) {
+        ApplicantSignupResponseDTO responseDTO = applicantAuthService.signup(requestDTO);
+
+        return ResponseEntity.ok(ApiResponse.success(201, responseDTO, "회원가입에 성공했습니다."));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<ApplicantLoginResponseDTO>> login(
+            @RequestBody
+            @Valid
+            ApplicantLoginRequestDTO requestDTO,
+            HttpServletResponse httpServletResponse
+    ) {
+        ApplicantLoginResult loginResult = applicantAuthService.login(requestDTO);
+
+        ResponseCookie refreshTokenCookie = cookieProvider.createRefreshTokenCookie(loginResult.refreshToken());
+
+        httpServletResponse.addHeader(
+                HttpHeaders.SET_COOKIE,
+                refreshTokenCookie.toString()
+        );
+
+        ApplicantLoginResponseDTO responseDTO = new ApplicantLoginResponseDTO(loginResult.accessToken(), loginResult.role());
+
+        return ResponseEntity.ok(ApiResponse.success(200, responseDTO, "로그인에 성공했습니다."));
+
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> withdraw(
+            Principal principal,
+            HttpServletResponse httpServletResponse
+    ) {
+        Long applicantId = extractedId(principal);
+
+        applicantAuthService.withdraw(applicantId);
+
+        ResponseCookie expiredRefreshTokenCookie = cookieProvider.createExpiredRefreshTokenCookie();
+
+        httpServletResponse.addHeader(
+                HttpHeaders.SET_COOKIE,
+                expiredRefreshTokenCookie.toString()
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(200, null, "회원탈퇴에 성공했습니다."));
+    }
+
+    private static Long extractedId(Principal principal) {
+        if(principal == null){
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return Long.parseLong(principal.getName());
+    }
+}

--- a/src/main/java/com/weiver/auth/controller/AuthController.java
+++ b/src/main/java/com/weiver/auth/controller/AuthController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantAgreementRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantAgreementRequestDTO.java
@@ -1,0 +1,24 @@
+package com.weiver.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ApplicantAgreementRequestDTO(
+        @NotNull(message = "서비스 이용 약관 동의 여부는 필수입니다.")
+        Boolean termsOfService,
+
+        @NotNull(message = "개인정보 처리방침 동의 여부는 필수입니다.")
+        Boolean privacyPolicy,
+
+        @NotNull(message = "개인회원 이용약관 동의 여부는 필수입니다.")
+        Boolean individualMemberTerms,
+
+        @NotNull(message = "AI 분석 서비스 이용동의 여부는 필수입니다.")
+        Boolean aiAnalysisConsent,
+
+        @NotNull(message = "민감정보 및 영상/음성 데이터 이용 동의 여부는 필수입니다.")
+        Boolean sensitiveDataConsent,
+
+        @NotNull(message = "마케팅 정보 수신 동의 여부를 선택해주세요.")
+        Boolean marketingConsent
+) {
+}

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantEmailSendRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantEmailSendRequestDTO.java
@@ -1,0 +1,11 @@
+package com.weiver.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ApplicantEmailSendRequestDTO(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email
+) {
+}

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantEmailVerifyRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantEmailVerifyRequestDTO.java
@@ -1,0 +1,16 @@
+package com.weiver.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ApplicantEmailVerifyRequestDTO(
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "인증번호는 필수 입력값입니다.")
+        @Pattern(regexp = "\\d{6}", message = "인증번호는 6자리 숫자여야 합니다.")
+        String code
+) {
+}

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantLoginRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantLoginRequestDTO.java
@@ -1,0 +1,15 @@
+package com.weiver.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ApplicantLoginRequestDTO(
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        String password
+) {
+}

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantLoginRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantLoginRequestDTO.java
@@ -2,7 +2,6 @@ package com.weiver.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 
 public record ApplicantLoginRequestDTO(
         @NotBlank(message = "이메일은 필수 입력값입니다.")

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantSignupRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantSignupRequestDTO.java
@@ -1,0 +1,28 @@
+package com.weiver.auth.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+
+public record ApplicantSignupRequestDTO(
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}:;\"'<>,.?/]).{8,64}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 각각 1자 이상 포함해야 합니다."
+        )
+        String password,
+
+        @NotBlank(message = "비밀번호 확인은 필수 입력값입니다.")
+        String passwordConfirm,
+
+        @NotBlank(message = "이메일 인증 토큰은 필수 입력값입니다.")
+        String verificationToken,
+
+        @Valid
+        @NotNull(message = "약관 동의 정보는 필수 입력값입니다.")
+        ApplicantAgreementRequestDTO agreements
+) {
+}

--- a/src/main/java/com/weiver/auth/dto/response/ApplicantEmailVerifyResponseDTO.java
+++ b/src/main/java/com/weiver/auth/dto/response/ApplicantEmailVerifyResponseDTO.java
@@ -1,0 +1,6 @@
+package com.weiver.auth.dto.response;
+
+public record ApplicantEmailVerifyResponseDTO(
+        String verificationToken
+) {
+}

--- a/src/main/java/com/weiver/auth/dto/response/ApplicantLoginResponseDTO.java
+++ b/src/main/java/com/weiver/auth/dto/response/ApplicantLoginResponseDTO.java
@@ -1,0 +1,9 @@
+package com.weiver.auth.dto.response;
+
+import com.weiver.global.common.UserRole;
+
+public record ApplicantLoginResponseDTO(
+        String accessToken,
+        UserRole role
+) {
+}

--- a/src/main/java/com/weiver/auth/dto/response/ApplicantSignupResponseDTO.java
+++ b/src/main/java/com/weiver/auth/dto/response/ApplicantSignupResponseDTO.java
@@ -1,0 +1,18 @@
+package com.weiver.auth.dto.response;
+
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.global.common.UserRole;
+
+public record ApplicantSignupResponseDTO(
+        Long applicantId,
+        String email,
+        UserRole role
+) {
+    public static ApplicantSignupResponseDTO from(Applicant applicant) {
+        return new ApplicantSignupResponseDTO(
+                applicant.getApplicantId(),
+                applicant.getEmail(),
+                applicant.getRole()
+        );
+    }
+}

--- a/src/main/java/com/weiver/auth/repository/ApplicantEmailVerificationRepository.java
+++ b/src/main/java/com/weiver/auth/repository/ApplicantEmailVerificationRepository.java
@@ -13,6 +13,7 @@ public class ApplicantEmailVerificationRepository {
 
     private static final String CODE_PREFIX = "applicant:email:code:";
     private static final String VERIFIED_TOKEN_PREFIX = "applicant:email:verified:";
+    private static final String ATTEMPT_PREFIX = "applicant:email:attempts:";
 
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -30,14 +31,21 @@ public class ApplicantEmailVerificationRepository {
         );
     }
 
-    public Optional<String> findAndDeleteCode(String email) {
-        return Optional.ofNullable(
-                redisTemplate.opsForValue().getAndDelete(generateCodeKey(email))
-        );
-    }
-
     public void deleteCode(String email) {
         redisTemplate.delete(generateCodeKey(email));
+    }
+
+    public long incrementAttemptCount(String email, Duration ttl) {
+        String key = generateAttemptKey(email);
+        Long count = redisTemplate.opsForValue().increment(key);
+        if (count != null && count == 1L) {
+            redisTemplate.expire(key, ttl);
+        }
+        return count == null ? 0L : count;
+    }
+
+    public void deleteAttemptCount(String email) {
+        redisTemplate.delete(generateAttemptKey(email));
     }
 
     public void saveVerifiedToken(String verificationToken, String email, Duration ttl) {
@@ -48,20 +56,10 @@ public class ApplicantEmailVerificationRepository {
         );
     }
 
-    public Optional<String> findEmailByVerifiedToken(String verifiedToken) {
-        return Optional.ofNullable(
-                redisTemplate.opsForValue().get(generateVerifiedTokenKey(verifiedToken))
-        );
-    }
-
     public Optional<String> findAndDeleteVerifiedToken(String verifiedToken) {
         return Optional.ofNullable(
                 redisTemplate.opsForValue().getAndDelete(generateVerifiedTokenKey(verifiedToken))
         );
-    }
-
-    public void deleteVerifiedToken(String verifiedToken) {
-        redisTemplate.delete(generateVerifiedTokenKey(verifiedToken));
     }
 
     private String generateCodeKey(String email) {
@@ -70,5 +68,9 @@ public class ApplicantEmailVerificationRepository {
 
     private String generateVerifiedTokenKey(String verifiedToken) {
         return VERIFIED_TOKEN_PREFIX + verifiedToken;
+    }
+
+    private String generateAttemptKey(String email) {
+        return ATTEMPT_PREFIX + email;
     }
 }

--- a/src/main/java/com/weiver/auth/repository/ApplicantEmailVerificationRepository.java
+++ b/src/main/java/com/weiver/auth/repository/ApplicantEmailVerificationRepository.java
@@ -1,0 +1,74 @@
+package com.weiver.auth.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ApplicantEmailVerificationRepository {
+
+    private static final String CODE_PREFIX = "applicant:email:code:";
+    private static final String VERIFIED_TOKEN_PREFIX = "applicant:email:verified:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveCode(String email, String code, Duration ttl) {
+        redisTemplate.opsForValue().set(
+                generateCodeKey(email),
+                code,
+                ttl
+        );
+    }
+
+    public Optional<String> findCodeByEmail(String email) {
+        return Optional.ofNullable(
+                redisTemplate.opsForValue().get(generateCodeKey(email))
+        );
+    }
+
+    public Optional<String> findAndDeleteCode(String email) {
+        return Optional.ofNullable(
+                redisTemplate.opsForValue().getAndDelete(generateCodeKey(email))
+        );
+    }
+
+    public void deleteCode(String email) {
+        redisTemplate.delete(generateCodeKey(email));
+    }
+
+    public void saveVerifiedToken(String verificationToken, String email, Duration ttl) {
+        redisTemplate.opsForValue().set(
+                generateVerifiedTokenKey(verificationToken),
+                email,
+                ttl
+        );
+    }
+
+    public Optional<String> findEmailByVerifiedToken(String verifiedToken) {
+        return Optional.ofNullable(
+                redisTemplate.opsForValue().get(generateVerifiedTokenKey(verifiedToken))
+        );
+    }
+
+    public Optional<String> findAndDeleteVerifiedToken(String verifiedToken) {
+        return Optional.ofNullable(
+                redisTemplate.opsForValue().getAndDelete(generateVerifiedTokenKey(verifiedToken))
+        );
+    }
+
+    public void deleteVerifiedToken(String verifiedToken) {
+        redisTemplate.delete(generateVerifiedTokenKey(verifiedToken));
+    }
+
+    private String generateCodeKey(String email) {
+        return CODE_PREFIX + email;
+    }
+
+    private String generateVerifiedTokenKey(String verifiedToken) {
+        return VERIFIED_TOKEN_PREFIX + verifiedToken;
+    }
+}

--- a/src/main/java/com/weiver/auth/service/ApplicantAuthService.java
+++ b/src/main/java/com/weiver/auth/service/ApplicantAuthService.java
@@ -31,6 +31,7 @@ public class ApplicantAuthService {
 
     private static final Duration EMAIL_CODE_TTL = Duration.ofMinutes(5);
     private static final Duration VERIFICATION_TOKEN_TTL = Duration.ofMinutes(30);
+    private static final int MAX_VERIFICATION_ATTEMPTS = 5;
 
     private final ApplicantRepository applicantRepository;
     private final ApplicantAgreementRepository applicantAgreementRepository;
@@ -50,6 +51,7 @@ public class ApplicantAuthService {
 
         String code = codeGenerator.generateCode();
 
+        emailVerificationRepository.deleteAttemptCount(email);
         emailVerificationRepository.saveCode(email, code, EMAIL_CODE_TTL);
 
         try {
@@ -67,17 +69,30 @@ public class ApplicantAuthService {
     public ApplicantEmailVerifyResponseDTO verifyEmailCode(ApplicantEmailVerifyRequestDTO request) {
         String email = request.email();
 
-        // 인증 코드를 atomic하게 조회 + 삭제 (한 번만 사용 가능)
-        String savedCode = emailVerificationRepository.findAndDeleteCode(email)
+        // 1) 코드 존재 여부만 확인 (소비하지 않음 - 시도 횟수 한도 내에선 재시도 허용)
+        String savedCode = emailVerificationRepository.findCodeByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.VERIFICATION_CODE_EXPIRED));
 
-        if(!savedCode.equals(request.code())) {
+        // 2) 시도 횟수 증가 (TTL은 코드와 동일하게 부여)
+        long attemptCount = emailVerificationRepository.incrementAttemptCount(email, EMAIL_CODE_TTL);
+
+        // 3) 한도 초과 시 코드/카운터 모두 소각하고 차단
+        if (attemptCount > MAX_VERIFICATION_ATTEMPTS) {
+            emailVerificationRepository.deleteCode(email);
+            emailVerificationRepository.deleteAttemptCount(email);
+            throw new BusinessException(ErrorCode.TOO_MANY_VERIFICATION_ATTEMPTS);
+        }
+
+        // 4) 코드 불일치 - 카운터는 살린 채 거절 (사용자가 한도 내에서 재시도 가능)
+        if (!savedCode.equals(request.code())) {
             throw new BusinessException(ErrorCode.INVALID_VERIFICATION_CODE);
         }
 
+        // 5) 일치 - 코드/카운터 정리 + verificationToken 발급
         String verificationToken = UUID.randomUUID().toString();
-
         emailVerificationRepository.saveVerifiedToken(verificationToken, email, VERIFICATION_TOKEN_TTL);
+        emailVerificationRepository.deleteCode(email);
+        emailVerificationRepository.deleteAttemptCount(email);
 
         return new ApplicantEmailVerifyResponseDTO(verificationToken);
     }

--- a/src/main/java/com/weiver/auth/service/ApplicantAuthService.java
+++ b/src/main/java/com/weiver/auth/service/ApplicantAuthService.java
@@ -1,0 +1,182 @@
+package com.weiver.auth.service;
+
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.domain.ApplicantAgreement;
+import com.weiver.applicant.repository.ApplicantAgreementRepository;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.auth.dto.request.*;
+import com.weiver.auth.dto.response.ApplicantEmailVerifyResponseDTO;
+import com.weiver.auth.dto.response.ApplicantSignupResponseDTO;
+import com.weiver.auth.repository.ApplicantEmailVerificationRepository;
+import com.weiver.auth.service.dto.ApplicantLoginResult;
+import com.weiver.global.common.UserRole;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import com.weiver.global.mail.MailMessage;
+import com.weiver.global.mail.MailSender;
+import com.weiver.global.security.jwt.JwtTokenProvider;
+import com.weiver.global.security.jwt.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicantAuthService {
+
+    private static final Duration EMAIL_CODE_TTL = Duration.ofMinutes(5);
+    private static final Duration VERIFICATION_TOKEN_TTL = Duration.ofMinutes(30);
+
+    private final ApplicantRepository applicantRepository;
+    private final ApplicantAgreementRepository applicantAgreementRepository;
+    private final ApplicantEmailVerificationRepository emailVerificationRepository;
+    private final ApplicantVerificationCodeGenerator codeGenerator;
+    private final MailSender mailSender;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void sendEmailCode(ApplicantEmailSendRequestDTO request) {
+        String email = request.email();
+
+        if(applicantRepository.existsByEmail(email)) {
+            throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        String code = codeGenerator.generateCode();
+
+        emailVerificationRepository.saveCode(email, code, EMAIL_CODE_TTL);
+
+        try {
+            mailSender.send(new MailMessage(
+                    email,
+                    "WEIVER 이메일 인증번호",
+                    "인증번호는 [" + code + "] 입니다."
+            ));
+        } catch (Exception e) {
+            emailVerificationRepository.deleteCode(email);
+            throw new BusinessException(ErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+
+    public ApplicantEmailVerifyResponseDTO verifyEmailCode(ApplicantEmailVerifyRequestDTO request) {
+        String email = request.email();
+
+        // 인증 코드를 atomic하게 조회 + 삭제 (한 번만 사용 가능)
+        String savedCode = emailVerificationRepository.findAndDeleteCode(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.VERIFICATION_CODE_EXPIRED));
+
+        if(!savedCode.equals(request.code())) {
+            throw new BusinessException(ErrorCode.INVALID_VERIFICATION_CODE);
+        }
+
+        String verificationToken = UUID.randomUUID().toString();
+
+        emailVerificationRepository.saveVerifiedToken(verificationToken, email, VERIFICATION_TOKEN_TTL);
+
+        return new ApplicantEmailVerifyResponseDTO(verificationToken);
+    }
+
+    @Transactional
+    public ApplicantSignupResponseDTO signup(ApplicantSignupRequestDTO request) {
+        validatePasswordConfirm(request.password(), request.passwordConfirm());
+        validateRequiredAgreements(request.agreements());
+
+        // verification 토큰을 atomic하게 소비 (한 번 시도하면 재사용 불가)
+        String verifiedEmail = emailVerificationRepository.findAndDeleteVerifiedToken(request.verificationToken())
+                .orElseThrow(() -> new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED));
+
+        if(!verifiedEmail.equals(request.email())) {
+            throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
+        Applicant applicant = Applicant.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .role(UserRole.APPLICANT)
+                .build();
+
+        Applicant savedApplicant;
+        try {
+            savedApplicant = applicantRepository.save(applicant);
+            applicantRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        ApplicantAgreement agreement = ApplicantAgreement.builder()
+                .applicant(savedApplicant)
+                .termsOfService(request.agreements().termsOfService())
+                .privacyPolicy(request.agreements().privacyPolicy())
+                .individualMemberTerms(request.agreements().individualMemberTerms())
+                .aiAnalysisConsent(request.agreements().aiAnalysisConsent())
+                .sensitiveDataConsent(request.agreements().sensitiveDataConsent())
+                .marketingConsent(request.agreements().marketingConsent())
+                .build();
+
+        applicantAgreementRepository.save(agreement);
+
+        return ApplicantSignupResponseDTO.from(savedApplicant);
+    }
+
+    @Transactional
+    public ApplicantLoginResult login(ApplicantLoginRequestDTO request) {
+        Applicant applicant = applicantRepository.findByEmailAndDeletedFalse(request.email())
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        if(!passwordEncoder.matches(request.password(), applicant.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(applicant.getApplicantId(), applicant.getRole());
+        String refreshToken = jwtTokenProvider.createRefreshToken(applicant.getApplicantId(), applicant.getRole());
+        long refreshTokenTtlMillis = jwtTokenProvider.getRemainingExpiration(refreshToken);
+
+        refreshTokenRepository.save(
+                applicant.getApplicantId(),
+                applicant.getRole(),
+                refreshToken,
+                refreshTokenTtlMillis
+        );
+
+        return new ApplicantLoginResult(
+                accessToken,
+                refreshToken,
+                applicant.getRole()
+        );
+    }
+
+    @Transactional
+    public void withdraw(Long applicantId) {
+        Applicant applicant = applicantRepository.findByApplicantIdAndDeletedFalse(applicantId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        refreshTokenRepository.deleteByUserId(
+                applicant.getApplicantId(),
+                applicant.getRole()
+        );
+
+        applicant.withdraw();
+    }
+
+    private void validatePasswordConfirm(String password, String passwordConfirm) {
+        if(!password.equals(passwordConfirm)) {
+            throw new BusinessException(ErrorCode.PASSWORD_CONFIRM_NOT_MATCH);
+        }
+    }
+
+    private void validateRequiredAgreements(ApplicantAgreementRequestDTO agreements) {
+        if(!Boolean.TRUE.equals(agreements.termsOfService())
+        || !Boolean.TRUE.equals(agreements.privacyPolicy())
+        || !Boolean.TRUE.equals(agreements.individualMemberTerms())
+        || !Boolean.TRUE.equals(agreements.aiAnalysisConsent())
+        || !Boolean.TRUE.equals(agreements.sensitiveDataConsent())) {
+            throw new BusinessException(ErrorCode.REQUIRED_AGREEMENT_NOT_ACCEPTED);
+        }
+    }
+}

--- a/src/main/java/com/weiver/auth/service/ApplicantVerificationCodeGenerator.java
+++ b/src/main/java/com/weiver/auth/service/ApplicantVerificationCodeGenerator.java
@@ -1,0 +1,16 @@
+package com.weiver.auth.service;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class ApplicantVerificationCodeGenerator {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public String generateCode() {
+        int number = RANDOM.nextInt(1_000_000);
+        return String.format("%06d", number);
+    }
+}

--- a/src/main/java/com/weiver/auth/service/dto/ApplicantLoginResult.java
+++ b/src/main/java/com/weiver/auth/service/dto/ApplicantLoginResult.java
@@ -1,0 +1,10 @@
+package com.weiver.auth.service.dto;
+
+import com.weiver.global.common.UserRole;
+
+public record ApplicantLoginResult(
+        String accessToken,
+        String refreshToken,
+        UserRole role
+) {
+}

--- a/src/main/java/com/weiver/global/config/SecurityConfig.java
+++ b/src/main/java/com/weiver/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.weiver.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -44,9 +45,16 @@ public class SecurityConfig {
                 );
 
         http.authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/logout").authenticated()
-                        .requestMatchers("/auth/reissue").permitAll()
-                        .anyRequest().permitAll()
+                        .requestMatchers(WhiteListConfig.swaggerWhitelist().toArray(String[]::new)).permitAll()
+                        .requestMatchers(WhiteListConfig.serverWhitelist().toArray(String[]::new)).permitAll()
+                        .requestMatchers(WhiteListConfig.authWhitelist().toArray(String[]::new)).permitAll()
+
+                        .requestMatchers(
+                                HttpMethod.POST,
+                                WhiteListConfig.applicantAuthWhitelist().toArray(String[]::new)
+                        ).permitAll()
+
+                        .anyRequest().authenticated()
                 );
 
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/weiver/global/config/WhiteListConfig.java
+++ b/src/main/java/com/weiver/global/config/WhiteListConfig.java
@@ -1,0 +1,43 @@
+package com.weiver.global.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class WhiteListConfig {
+
+    // Swagger 관련 인가 설정
+    public static List<String> swaggerWhitelist() {
+        return List.of(
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html"
+        );
+    }
+
+    // 인증 없이 접근 가능한 공통 Auth API
+    public static List<String> authWhitelist() {
+        return List.of(
+                "/api/auth/reissue"
+        );
+    }
+
+    // 구직자 인증/회원가입 관련 인가 설정
+    public static List<String> applicantAuthWhitelist() {
+        return List.of(
+                "/api/auth/applicants/email/send",
+                "/api/auth/applicants/email/verify",
+                "/api/auth/applicants/signup",
+                "/api/auth/applicants/login"
+        );
+    }
+
+    // 서버 상태 확인, 운영 편의 API
+    public static List<String> serverWhitelist() {
+        return List.of(
+                "/actuator/health"
+        );
+    }
+}

--- a/src/main/java/com/weiver/global/exception/ErrorCode.java
+++ b/src/main/java/com/weiver/global/exception/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
     APPLICANT_NOT_FOUND("APPLICANT_NOT_FOUND", HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     APPLICANT_ALREADY_EXISTS("APPLICANT_ALREADY_EXISTS", HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
     INVALID_PASSWORD("INVALID_PASSWORD", HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다."),
+    PASSWORD_CONFIRM_NOT_MATCH("PASSWORD_CONFIRM_NOT_MATCH", HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    REQUIRED_AGREEMENT_NOT_ACCEPTED("REQUIRED_AGREEMENT_NOT_ACCEPTED", HttpStatus.BAD_REQUEST, "필수 약관에 동의해야 합니다."),
 
     // ===================== COMPANY =====================
     COMPANY_NOT_FOUND("COMPANY_NOT_FOUND", HttpStatus.NOT_FOUND, "존재하지 않는 기업입니다."),

--- a/src/main/java/com/weiver/global/exception/ErrorCode.java
+++ b/src/main/java/com/weiver/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     EMAIL_SEND_FAILED("EMAIL_SEND_FAILED", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 인증번호 전송에 실패했습니다."),
     INVALID_VERIFICATION_CODE("INVALID_VERIFICATION_CODE", HttpStatus.BAD_REQUEST, "이메일 인증번호가 올바르지 않습니다."),
     VERIFICATION_CODE_EXPIRED("VERIFICATION_CODE_EXPIRED", HttpStatus.BAD_REQUEST, "이메일 인증번호가 만료되었습니다. 다시 요청해 주세요."),
+    TOO_MANY_VERIFICATION_ATTEMPTS("TOO_MANY_VERIFICATION_ATTEMPTS", HttpStatus.BAD_REQUEST, "인증 시도 횟수를 초과했습니다. 인증번호를 다시 요청해 주세요."),
     EMAIL_NOT_VERIFIED("EMAIL_NOT_VERIFIED", HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
 
     // ===================== VALIDATION =====================

--- a/src/main/java/com/weiver/global/exception/ErrorCode.java
+++ b/src/main/java/com/weiver/global/exception/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode {
     UNAUTHORIZED("UNAUTHORIZED", HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     FORBIDDEN("FORBIDDEN", HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     MISSING_COOKIE("MISSING_COOKIE", HttpStatus.BAD_REQUEST, "필수 쿠키가 누락되었습니다."),
-    USER_NOT_FOUND("USER_NOT_FOUNT", HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    USER_NOT_FOUND("USER_NOT_FOUND", HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
 
     // ===================== TOKEN =====================
     TOKEN_EXPIRED("TOKEN_EXPIRED", HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),

--- a/src/main/java/com/weiver/global/mail/LoggingMailSender.java
+++ b/src/main/java/com/weiver/global/mail/LoggingMailSender.java
@@ -1,0 +1,17 @@
+package com.weiver.global.mail;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Profile("local")
+@Component
+public class LoggingMailSender implements MailSender {
+
+    @Override
+    public void send(MailMessage message) {
+        log.info("[Mail] to={}, subject={}, body={}",
+                message.to(), message.subject(), message.body());
+    }
+}

--- a/src/main/java/com/weiver/global/mail/MailMessage.java
+++ b/src/main/java/com/weiver/global/mail/MailMessage.java
@@ -1,0 +1,8 @@
+package com.weiver.global.mail;
+
+public record MailMessage(
+        String to,
+        String subject,
+        String body
+) {
+}

--- a/src/main/java/com/weiver/global/mail/MailSender.java
+++ b/src/main/java/com/weiver/global/mail/MailSender.java
@@ -1,0 +1,5 @@
+package com.weiver.global.mail;
+
+public interface MailSender {
+    void send(MailMessage message);
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -11,6 +11,9 @@ server:
     include-stacktrace: always
 
 spring:
+  config:
+    activate:
+      on-profile: local
   # ---------------------------------------------------------------------------
   # PostgreSQL - 로컬 Docker 컨테이너
   # ---------------------------------------------------------------------------
@@ -34,7 +37,7 @@ spring:
   # ---------------------------------------------------------------------------
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create-drop
     show-sql: true
     open-in-view: false
     properties:
@@ -92,6 +95,20 @@ ai:
 # =============================================================================
 jwt:
   secret: local-dev-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm
+  access-token-expiration: 3600000 # 1 hour
+  refresh-token-expiration: 1209600000 # 14 days
+
+# =============================================================================
+# COOKIE 설정
+# =============================================================================
+cookie:
+  refresh-token:
+    name: refreshToken
+    path: /
+    http-only: true
+    secure: false
+    same-site: Lax
+    max-age: 1209600 # 14 days
 
 # =============================================================================
 # Swagger / SpringDoc 설정

--- a/src/test/java/com/weiver/domain/auth/controller/ApplicantAuthControllerTest.java
+++ b/src/test/java/com/weiver/domain/auth/controller/ApplicantAuthControllerTest.java
@@ -1,0 +1,258 @@
+package com.weiver.domain.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.auth.controller.ApplicantAuthController;
+import com.weiver.auth.dto.request.ApplicantAgreementRequestDTO;
+import com.weiver.auth.dto.request.ApplicantEmailSendRequestDTO;
+import com.weiver.auth.dto.request.ApplicantEmailVerifyRequestDTO;
+import com.weiver.auth.dto.request.ApplicantLoginRequestDTO;
+import com.weiver.auth.dto.request.ApplicantSignupRequestDTO;
+import com.weiver.auth.dto.response.ApplicantEmailVerifyResponseDTO;
+import com.weiver.auth.dto.response.ApplicantSignupResponseDTO;
+import com.weiver.auth.service.ApplicantAuthService;
+import com.weiver.auth.service.dto.ApplicantLoginResult;
+import com.weiver.global.common.UserRole;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import com.weiver.global.security.cookie.CookieProvider;
+import com.weiver.global.security.cookie.RefreshTokenCookieResolver;
+import com.weiver.global.security.jwt.BearerTokenResolver;
+import com.weiver.global.security.jwt.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApplicantAuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class ApplicantAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean private ApplicantAuthService applicantAuthService;
+    @MockitoBean private CookieProvider cookieProvider;
+    @MockitoBean private BearerTokenResolver bearerTokenResolver;
+    @MockitoBean private RefreshTokenCookieResolver refreshTokenCookieResolver;
+    @MockitoBean private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    @DisplayName("이메일 인증번호 전송 성공 시 200 응답")
+    public void sendEmailCode_success() throws Exception {
+        // given
+        ApplicantEmailSendRequestDTO request = new ApplicantEmailSendRequestDTO("user@test.com");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/email/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("이메일 인증번호 전송에 성공했습니다."));
+
+        verify(applicantAuthService).sendEmailCode(any(ApplicantEmailSendRequestDTO.class));
+    }
+
+    @Test
+    @DisplayName("엣지 케이스: 이메일 형식 오류 -> 400 Bad Request")
+    public void sendEmailCode_invalidEmail() throws Exception {
+        // given
+        ApplicantEmailSendRequestDTO request = new ApplicantEmailSendRequestDTO("not-email");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/email/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 확인 성공 시 verificationToken 반환")
+    public void verifyEmailCode_success() throws Exception {
+        // given
+        ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO("user@test.com", "123456");
+        when(applicantAuthService.verifyEmailCode(any()))
+                .thenReturn(new ApplicantEmailVerifyResponseDTO("verification-token"));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/email/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.verificationToken").value("verification-token"))
+                .andExpect(jsonPath("$.message").value("이메일 인증번호 확인에 성공했습니다."));
+    }
+
+    @Test
+    @DisplayName("엣지 케이스: 인증번호 만료 시 400 VERIFICATION_CODE_EXPIRED")
+    public void verifyEmailCode_expired() throws Exception {
+        // given
+        ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO("user@test.com", "123456");
+        when(applicantAuthService.verifyEmailCode(any()))
+                .thenThrow(new BusinessException(ErrorCode.VERIFICATION_CODE_EXPIRED));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/email/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("VERIFICATION_CODE_EXPIRED"));
+    }
+
+    @Test
+    @DisplayName("엣지 케이스: 인증번호가 6자리 숫자가 아니면 400 Bad Request")
+    public void verifyEmailCode_invalidCodeFormat() throws Exception {
+        // given
+        ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO("user@test.com", "12ab56");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/email/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 시 201 응답과 ApplicantSignupResponseDTO 반환")
+    public void signup_success() throws Exception {
+        // given
+        ApplicantSignupRequestDTO request = new ApplicantSignupRequestDTO(
+                "new@test.com", "Pass1234!", "Pass1234!", "verification-token", allTrueAgreements()
+        );
+        when(applicantAuthService.signup(any()))
+                .thenReturn(new ApplicantSignupResponseDTO(1L, "new@test.com", UserRole.APPLICANT));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk()) // ResponseEntity.ok()로 감쌈
+                .andExpect(jsonPath("$.code").value(201))
+                .andExpect(jsonPath("$.data.applicantId").value(1))
+                .andExpect(jsonPath("$.data.email").value("new@test.com"))
+                .andExpect(jsonPath("$.data.role").value("APPLICANT"))
+                .andExpect(jsonPath("$.message").value("회원가입에 성공했습니다."));
+    }
+
+    @Test
+    @DisplayName("엣지 케이스: 비밀번호 복잡도 미달 -> 400 Bad Request")
+    public void signup_weakPassword() throws Exception {
+        // given - 영문만, 숫자/특수문자 없음
+        ApplicantSignupRequestDTO request = new ApplicantSignupRequestDTO(
+                "new@test.com", "onlyletters", "onlyletters", "token", allTrueAgreements()
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("엣지 케이스: 이미 가입된 이메일이면 409 EMAIL_ALREADY_EXISTS")
+    public void signup_emailAlreadyExists() throws Exception {
+        // given
+        ApplicantSignupRequestDTO request = new ApplicantSignupRequestDTO(
+                "exists@test.com", "Pass1234!", "Pass1234!", "token", allTrueAgreements()
+        );
+        when(applicantAuthService.signup(any()))
+                .thenThrow(new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("EMAIL_ALREADY_EXISTS"));
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 accessToken 반환 + RefreshToken 쿠키 설정")
+    public void login_success() throws Exception {
+        // given
+        ApplicantLoginRequestDTO request = new ApplicantLoginRequestDTO("user@test.com", "Pass1234!");
+        when(applicantAuthService.login(any()))
+                .thenReturn(new ApplicantLoginResult("access", "refresh", UserRole.APPLICANT));
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", "refresh")
+                .path("/").httpOnly(true).secure(false).sameSite("Lax").maxAge(1209600).build();
+        when(cookieProvider.createRefreshTokenCookie("refresh")).thenReturn(refreshCookie);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=refresh")))
+                .andExpect(jsonPath("$.data.accessToken").value("access"))
+                .andExpect(jsonPath("$.data.role").value("APPLICANT"))
+                .andExpect(jsonPath("$.message").value("로그인에 성공했습니다."));
+    }
+
+    @Test
+    @DisplayName("엣지 케이스: 비밀번호 불일치 시 401 INVALID_PASSWORD")
+    public void login_invalidPassword() throws Exception {
+        // given
+        ApplicantLoginRequestDTO request = new ApplicantLoginRequestDTO("user@test.com", "wrong");
+        when(applicantAuthService.login(any()))
+                .thenThrow(new BusinessException(ErrorCode.INVALID_PASSWORD));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/applicants/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_PASSWORD"));
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 성공 시 200 응답 + RefreshToken 쿠키 만료")
+    public void withdraw_success() throws Exception {
+        // given
+        ResponseCookie expiredCookie = ResponseCookie.from("refreshToken", "")
+                .path("/").httpOnly(true).secure(false).sameSite("Lax").maxAge(0).build();
+        when(cookieProvider.createExpiredRefreshTokenCookie()).thenReturn(expiredCookie);
+
+        // when & then
+        mockMvc.perform(delete("/api/auth/applicants/me")
+                        .principal(() -> "1"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=")))
+                .andExpect(jsonPath("$.message").value("회원탈퇴에 성공했습니다."));
+
+        verify(applicantAuthService).withdraw(1L);
+    }
+
+    @Test
+    @DisplayName("엣지 케이스: Principal이 없으면 401 UNAUTHORIZED")
+    public void withdraw_unauthorized() throws Exception {
+        mockMvc.perform(delete("/api/auth/applicants/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    private static ApplicantAgreementRequestDTO allTrueAgreements() {
+        return new ApplicantAgreementRequestDTO(true, true, true, true, true, true);
+    }
+}

--- a/src/test/java/com/weiver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/weiver/domain/auth/controller/AuthControllerTest.java
@@ -62,7 +62,7 @@ public class AuthControllerTest {
         when(cookieProvider.createExpiredRefreshTokenCookie()).thenReturn(expiredCookie);
 
         // when & then
-        mockMvc.perform(post("/auth/logout")
+        mockMvc.perform(post("/api/auth/logout")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -83,7 +83,7 @@ public class AuthControllerTest {
                 .thenThrow(new BusinessException(ErrorCode.INVALID_TOKEN));
 
         // when & then
-        mockMvc.perform(post("/auth/logout")
+        mockMvc.perform(post("/api/auth/logout")
                 .header(HttpHeaders.AUTHORIZATION, "invalidToken")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized())

--- a/src/test/java/com/weiver/domain/auth/service/ApplicantAuthServiceTest.java
+++ b/src/test/java/com/weiver/domain/auth/service/ApplicantAuthServiceTest.java
@@ -1,0 +1,429 @@
+package com.weiver.domain.auth.service;
+
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.domain.ApplicantAgreement;
+import com.weiver.applicant.repository.ApplicantAgreementRepository;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.auth.dto.request.ApplicantAgreementRequestDTO;
+import com.weiver.auth.dto.request.ApplicantEmailSendRequestDTO;
+import com.weiver.auth.dto.request.ApplicantEmailVerifyRequestDTO;
+import com.weiver.auth.dto.request.ApplicantLoginRequestDTO;
+import com.weiver.auth.dto.request.ApplicantSignupRequestDTO;
+import com.weiver.auth.dto.response.ApplicantEmailVerifyResponseDTO;
+import com.weiver.auth.dto.response.ApplicantSignupResponseDTO;
+import com.weiver.auth.repository.ApplicantEmailVerificationRepository;
+import com.weiver.auth.service.ApplicantAuthService;
+import com.weiver.auth.service.ApplicantVerificationCodeGenerator;
+import com.weiver.auth.service.dto.ApplicantLoginResult;
+import com.weiver.global.common.UserRole;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import com.weiver.global.mail.MailMessage;
+import com.weiver.global.mail.MailSender;
+import com.weiver.global.security.jwt.JwtTokenProvider;
+import com.weiver.global.security.jwt.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ApplicantAuthServiceTest {
+
+    @InjectMocks
+    private ApplicantAuthService applicantAuthService;
+
+    @Mock private ApplicantRepository applicantRepository;
+    @Mock private ApplicantAgreementRepository applicantAgreementRepository;
+    @Mock private ApplicantEmailVerificationRepository emailVerificationRepository;
+    @Mock private ApplicantVerificationCodeGenerator codeGenerator;
+    @Mock private MailSender mailSender;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    @DisplayName("이메일 인증번호 전송 성공 시 코드를 Redis에 저장하고 메일을 발송한다.")
+    public void sendEmailCode_success() {
+        // given
+        String email = "user@test.com";
+        String code = "123456";
+        ApplicantEmailSendRequestDTO request = new ApplicantEmailSendRequestDTO(email);
+
+        when(applicantRepository.existsByEmail(email)).thenReturn(false);
+        when(codeGenerator.generateCode()).thenReturn(code);
+
+        // when
+        applicantAuthService.sendEmailCode(request);
+
+        // then
+        verify(emailVerificationRepository).saveCode(eq(email), eq(code), any(Duration.class));
+        verify(mailSender).send(any(MailMessage.class));
+        verify(emailVerificationRepository, never()).deleteCode(anyString());
+    }
+
+    @Test
+    @DisplayName("이미 가입된 이메일이면 EMAIL_ALREADY_EXISTS 예외 발생")
+    public void sendEmailCode_emailAlreadyExists() {
+        // given
+        String email = "exists@test.com";
+        ApplicantEmailSendRequestDTO request = new ApplicantEmailSendRequestDTO(email);
+
+        when(applicantRepository.existsByEmail(email)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.sendEmailCode(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.EMAIL_ALREADY_EXISTS.defaultMessage);
+
+        verify(codeGenerator, never()).generateCode();
+        verify(emailVerificationRepository, never()).saveCode(anyString(), anyString(), any(Duration.class));
+        verify(mailSender, never()).send(any(MailMessage.class));
+    }
+
+    @Test
+    @DisplayName("메일 발송 실패 시 저장한 코드를 삭제하고 EMAIL_SEND_FAILED 예외 발생")
+    public void sendEmailCode_mailSendFails() {
+        // given
+        String email = "user@test.com";
+        String code = "123456";
+        ApplicantEmailSendRequestDTO request = new ApplicantEmailSendRequestDTO(email);
+
+        when(applicantRepository.existsByEmail(email)).thenReturn(false);
+        when(codeGenerator.generateCode()).thenReturn(code);
+        doThrow(new RuntimeException("smtp down")).when(mailSender).send(any(MailMessage.class));
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.sendEmailCode(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.EMAIL_SEND_FAILED.defaultMessage);
+
+        verify(emailVerificationRepository).saveCode(eq(email), eq(code), any(Duration.class));
+        verify(emailVerificationRepository).deleteCode(email);
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 검증 성공 시 코드를 atomic하게 소비하고 verificationToken을 발급한다.")
+    public void verifyEmailCode_success() {
+        // given
+        String email = "user@test.com";
+        String code = "123456";
+        ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO(email, code);
+
+        when(emailVerificationRepository.findAndDeleteCode(email)).thenReturn(Optional.of(code));
+
+        // when
+        ApplicantEmailVerifyResponseDTO response = applicantAuthService.verifyEmailCode(request);
+
+        // then
+        assertThat(response.verificationToken()).isNotBlank();
+        verify(emailVerificationRepository).findAndDeleteCode(email);
+        verify(emailVerificationRepository).saveVerifiedToken(eq(response.verificationToken()), eq(email), any(Duration.class));
+        verify(emailVerificationRepository, never()).deleteCode(anyString());
+    }
+
+    @Test
+    @DisplayName("저장된 코드가 없으면 VERIFICATION_CODE_EXPIRED 예외 발생")
+    public void verifyEmailCode_expired() {
+        // given
+        String email = "user@test.com";
+        ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO(email, "123456");
+
+        when(emailVerificationRepository.findAndDeleteCode(email)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.verifyEmailCode(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.VERIFICATION_CODE_EXPIRED.defaultMessage);
+
+        verify(emailVerificationRepository, never()).saveVerifiedToken(anyString(), anyString(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("입력 코드가 저장된 코드와 다르면 INVALID_VERIFICATION_CODE 예외 발생 (코드는 이미 burn 됨)")
+    public void verifyEmailCode_invalidCode() {
+        // given
+        String email = "user@test.com";
+        ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO(email, "111111");
+
+        when(emailVerificationRepository.findAndDeleteCode(email)).thenReturn(Optional.of("999999"));
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.verifyEmailCode(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_VERIFICATION_CODE.defaultMessage);
+
+        verify(emailVerificationRepository).findAndDeleteCode(email);
+        verify(emailVerificationRepository, never()).saveVerifiedToken(anyString(), anyString(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 시 토큰 소비 -> Applicant 저장 -> Agreement 저장 순으로 수행한다.")
+    public void signup_success() {
+        // given
+        String email = "new@test.com";
+        String password = "Pass1234!";
+        String token = "verification-token";
+        ApplicantSignupRequestDTO request = new ApplicantSignupRequestDTO(
+                email, password, password, token, allTrueAgreements()
+        );
+
+        when(emailVerificationRepository.findAndDeleteVerifiedToken(token))
+                .thenReturn(Optional.of(email));
+        when(passwordEncoder.encode(password)).thenReturn("encoded");
+
+        Applicant saved = Applicant.builder()
+                .email(email)
+                .password("encoded")
+                .role(UserRole.APPLICANT)
+                .build();
+        ReflectionTestUtils.setField(saved, "applicantId", 1L);
+        when(applicantRepository.save(any(Applicant.class))).thenReturn(saved);
+
+        // when
+        ApplicantSignupResponseDTO response = applicantAuthService.signup(request);
+
+        // then
+        assertThat(response.applicantId()).isEqualTo(1L);
+        assertThat(response.email()).isEqualTo(email);
+        assertThat(response.role()).isEqualTo(UserRole.APPLICANT);
+
+        verify(emailVerificationRepository).findAndDeleteVerifiedToken(token);
+        verify(applicantRepository).save(any(Applicant.class));
+        verify(applicantRepository).flush();
+        verify(applicantAgreementRepository).save(any(ApplicantAgreement.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호와 비밀번호 확인이 다르면 PASSWORD_CONFIRM_NOT_MATCH 예외 (토큰 소비 안 함)")
+    public void signup_passwordConfirmMismatch() {
+        // given
+        ApplicantSignupRequestDTO request = new ApplicantSignupRequestDTO(
+                "user@test.com", "Pass1234!", "Different1!", "token", allTrueAgreements()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.PASSWORD_CONFIRM_NOT_MATCH.defaultMessage);
+
+        verify(emailVerificationRepository, never()).findAndDeleteVerifiedToken(anyString());
+        verify(applicantRepository, never()).save(any(Applicant.class));
+    }
+
+    @Test
+    @DisplayName("필수 약관 미동의 시 REQUIRED_AGREEMENT_NOT_ACCEPTED 예외 (토큰 소비 안 함)")
+    public void signup_requiredAgreementNotAccepted() {
+        // given
+        ApplicantAgreementRequestDTO partial = new ApplicantAgreementRequestDTO(
+                true, true, true, true, false, true
+        );
+        ApplicantSignupRequestDTO request = new ApplicantSignupRequestDTO(
+                "user@test.com", "Pass1234!", "Pass1234!", "token", partial
+        );
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.REQUIRED_AGREEMENT_NOT_ACCEPTED.defaultMessage);
+
+        verify(emailVerificationRepository, never()).findAndDeleteVerifiedToken(anyString());
+        verify(applicantRepository, never()).save(any(Applicant.class));
+    }
+
+    @Test
+    @DisplayName("verification 토큰이 Redis에 없으면 EMAIL_NOT_VERIFIED 예외")
+    public void signup_verificationTokenNotFound() {
+        // given
+        String token = "missing-token";
+        ApplicantSignupRequestDTO request = new ApplicantSignupRequestDTO(
+                "user@test.com", "Pass1234!", "Pass1234!", token, allTrueAgreements()
+        );
+
+        when(emailVerificationRepository.findAndDeleteVerifiedToken(token))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.EMAIL_NOT_VERIFIED.defaultMessage);
+
+        verify(applicantRepository, never()).save(any(Applicant.class));
+    }
+
+    @Test
+    @DisplayName("verification 토큰의 이메일과 요청 이메일이 다르면 EMAIL_NOT_VERIFIED 예외")
+    public void signup_emailMismatch() {
+        // given
+        String token = "token";
+        ApplicantSignupRequestDTO request = new ApplicantSignupRequestDTO(
+                "request@test.com", "Pass1234!", "Pass1234!", token, allTrueAgreements()
+        );
+
+        when(emailVerificationRepository.findAndDeleteVerifiedToken(token))
+                .thenReturn(Optional.of("other@test.com"));
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.EMAIL_NOT_VERIFIED.defaultMessage);
+
+        verify(applicantRepository, never()).save(any(Applicant.class));
+    }
+
+    @Test
+    @DisplayName("DB unique 제약 위반(race condition)으로 가입 실패 시 EMAIL_ALREADY_EXISTS 예외")
+    public void signup_uniqueViolationOnRace() {
+        // given
+        String email = "race@test.com";
+        String token = "token";
+        ApplicantSignupRequestDTO request = new ApplicantSignupRequestDTO(
+                email, "Pass1234!", "Pass1234!", token, allTrueAgreements()
+        );
+
+        when(emailVerificationRepository.findAndDeleteVerifiedToken(token))
+                .thenReturn(Optional.of(email));
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded");
+        when(applicantRepository.save(any(Applicant.class)))
+                .thenThrow(new DataIntegrityViolationException("unique violation"));
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.EMAIL_ALREADY_EXISTS.defaultMessage);
+
+        verify(applicantAgreementRepository, never()).save(any(ApplicantAgreement.class));
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 access/refresh 토큰을 발급하고 RefreshToken을 저장한다.")
+    public void login_success() {
+        // given
+        String email = "user@test.com";
+        String rawPassword = "Pass1234!";
+        ApplicantLoginRequestDTO request = new ApplicantLoginRequestDTO(email, rawPassword);
+
+        Applicant applicant = Applicant.builder()
+                .email(email)
+                .password("encoded")
+                .role(UserRole.APPLICANT)
+                .build();
+        ReflectionTestUtils.setField(applicant, "applicantId", 7L);
+
+        when(applicantRepository.findByEmailAndDeletedFalse(email)).thenReturn(Optional.of(applicant));
+        when(passwordEncoder.matches(rawPassword, "encoded")).thenReturn(true);
+        when(jwtTokenProvider.createAccessToken(7L, UserRole.APPLICANT)).thenReturn("access");
+        when(jwtTokenProvider.createRefreshToken(7L, UserRole.APPLICANT)).thenReturn("refresh");
+        when(jwtTokenProvider.getRemainingExpiration("refresh")).thenReturn(1000L);
+
+        // when
+        ApplicantLoginResult result = applicantAuthService.login(request);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo("access");
+        assertThat(result.refreshToken()).isEqualTo("refresh");
+        assertThat(result.role()).isEqualTo(UserRole.APPLICANT);
+        verify(refreshTokenRepository).save(7L, UserRole.APPLICANT, "refresh", 1000L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일이면 APPLICANT_NOT_FOUND 예외")
+    public void login_applicantNotFound() {
+        // given
+        ApplicantLoginRequestDTO request = new ApplicantLoginRequestDTO("none@test.com", "Pass1234!");
+        when(applicantRepository.findByEmailAndDeletedFalse("none@test.com")).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.login(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.APPLICANT_NOT_FOUND.defaultMessage);
+
+        verify(jwtTokenProvider, never()).createAccessToken(anyLong(), any(UserRole.class));
+        verify(refreshTokenRepository, never()).save(anyLong(), any(UserRole.class), anyString(), anyLong());
+    }
+
+    @Test
+    @DisplayName("비밀번호가 일치하지 않으면 INVALID_PASSWORD 예외")
+    public void login_invalidPassword() {
+        // given
+        ApplicantLoginRequestDTO request = new ApplicantLoginRequestDTO("user@test.com", "wrong");
+        Applicant applicant = Applicant.builder()
+                .email("user@test.com")
+                .password("encoded")
+                .role(UserRole.APPLICANT)
+                .build();
+        ReflectionTestUtils.setField(applicant, "applicantId", 1L);
+
+        when(applicantRepository.findByEmailAndDeletedFalse("user@test.com")).thenReturn(Optional.of(applicant));
+        when(passwordEncoder.matches("wrong", "encoded")).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.login(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_PASSWORD.defaultMessage);
+
+        verify(jwtTokenProvider, never()).createAccessToken(anyLong(), any(UserRole.class));
+        verify(refreshTokenRepository, never()).save(anyLong(), any(UserRole.class), anyString(), anyLong());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 성공 시 RefreshToken 삭제 후 Applicant를 soft-delete 처리한다.")
+    public void withdraw_success() {
+        // given
+        Long applicantId = 5L;
+        Applicant applicant = Applicant.builder()
+                .email("user@test.com")
+                .password("encoded")
+                .role(UserRole.APPLICANT)
+                .build();
+        ReflectionTestUtils.setField(applicant, "applicantId", applicantId);
+
+        when(applicantRepository.findByApplicantIdAndDeletedFalse(applicantId))
+                .thenReturn(Optional.of(applicant));
+
+        // when
+        applicantAuthService.withdraw(applicantId);
+
+        // then
+        verify(refreshTokenRepository).deleteByUserId(applicantId, UserRole.APPLICANT);
+        assertThat(applicant.isDeleted()).isTrue();
+        assertThat(applicant.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("탈퇴 대상 사용자가 없으면 APPLICANT_NOT_FOUND 예외")
+    public void withdraw_applicantNotFound() {
+        // given
+        when(applicantRepository.findByApplicantIdAndDeletedFalse(99L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.withdraw(99L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.APPLICANT_NOT_FOUND.defaultMessage);
+
+        verify(refreshTokenRepository, never()).deleteByUserId(anyLong(), any(UserRole.class));
+    }
+
+    private static ApplicantAgreementRequestDTO allTrueAgreements() {
+        return new ApplicantAgreementRequestDTO(true, true, true, true, true, true);
+    }
+}

--- a/src/test/java/com/weiver/domain/auth/service/ApplicantAuthServiceTest.java
+++ b/src/test/java/com/weiver/domain/auth/service/ApplicantAuthServiceTest.java
@@ -62,7 +62,7 @@ public class ApplicantAuthServiceTest {
     @Mock private RefreshTokenRepository refreshTokenRepository;
 
     @Test
-    @DisplayName("이메일 인증번호 전송 성공 시 코드를 Redis에 저장하고 메일을 발송한다.")
+    @DisplayName("이메일 인증번호 전송 성공 시 시도 카운터 초기화 후 코드 저장 + 메일 발송")
     public void sendEmailCode_success() {
         // given
         String email = "user@test.com";
@@ -76,6 +76,7 @@ public class ApplicantAuthServiceTest {
         applicantAuthService.sendEmailCode(request);
 
         // then
+        verify(emailVerificationRepository).deleteAttemptCount(email);
         verify(emailVerificationRepository).saveCode(eq(email), eq(code), any(Duration.class));
         verify(mailSender).send(any(MailMessage.class));
         verify(emailVerificationRepository, never()).deleteCode(anyString());
@@ -117,62 +118,92 @@ public class ApplicantAuthServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.EMAIL_SEND_FAILED.defaultMessage);
 
+        verify(emailVerificationRepository).deleteAttemptCount(email);
         verify(emailVerificationRepository).saveCode(eq(email), eq(code), any(Duration.class));
         verify(emailVerificationRepository).deleteCode(email);
     }
 
     @Test
-    @DisplayName("이메일 인증번호 검증 성공 시 코드를 atomic하게 소비하고 verificationToken을 발급한다.")
+    @DisplayName("이메일 인증번호 검증 성공 시 코드/카운터를 정리하고 verificationToken을 발급한다.")
     public void verifyEmailCode_success() {
         // given
         String email = "user@test.com";
         String code = "123456";
         ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO(email, code);
 
-        when(emailVerificationRepository.findAndDeleteCode(email)).thenReturn(Optional.of(code));
+        when(emailVerificationRepository.findCodeByEmail(email)).thenReturn(Optional.of(code));
+        when(emailVerificationRepository.incrementAttemptCount(eq(email), any(Duration.class))).thenReturn(1L);
 
         // when
         ApplicantEmailVerifyResponseDTO response = applicantAuthService.verifyEmailCode(request);
 
         // then
         assertThat(response.verificationToken()).isNotBlank();
-        verify(emailVerificationRepository).findAndDeleteCode(email);
+        verify(emailVerificationRepository).findCodeByEmail(email);
+        verify(emailVerificationRepository).incrementAttemptCount(eq(email), any(Duration.class));
         verify(emailVerificationRepository).saveVerifiedToken(eq(response.verificationToken()), eq(email), any(Duration.class));
-        verify(emailVerificationRepository, never()).deleteCode(anyString());
+        verify(emailVerificationRepository).deleteCode(email);
+        verify(emailVerificationRepository).deleteAttemptCount(email);
     }
 
     @Test
-    @DisplayName("저장된 코드가 없으면 VERIFICATION_CODE_EXPIRED 예외 발생")
+    @DisplayName("저장된 코드가 없으면 VERIFICATION_CODE_EXPIRED 예외 (카운터 증가 없음)")
     public void verifyEmailCode_expired() {
         // given
         String email = "user@test.com";
         ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO(email, "123456");
 
-        when(emailVerificationRepository.findAndDeleteCode(email)).thenReturn(Optional.empty());
+        when(emailVerificationRepository.findCodeByEmail(email)).thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> applicantAuthService.verifyEmailCode(request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.VERIFICATION_CODE_EXPIRED.defaultMessage);
 
+        verify(emailVerificationRepository, never()).incrementAttemptCount(anyString(), any(Duration.class));
         verify(emailVerificationRepository, never()).saveVerifiedToken(anyString(), anyString(), any(Duration.class));
     }
 
     @Test
-    @DisplayName("입력 코드가 저장된 코드와 다르면 INVALID_VERIFICATION_CODE 예외 발생 (코드는 이미 burn 됨)")
+    @DisplayName("코드 불일치 시 INVALID_VERIFICATION_CODE 예외 (코드/카운터는 살아있음)")
     public void verifyEmailCode_invalidCode() {
         // given
         String email = "user@test.com";
         ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO(email, "111111");
 
-        when(emailVerificationRepository.findAndDeleteCode(email)).thenReturn(Optional.of("999999"));
+        when(emailVerificationRepository.findCodeByEmail(email)).thenReturn(Optional.of("999999"));
+        when(emailVerificationRepository.incrementAttemptCount(eq(email), any(Duration.class))).thenReturn(2L);
 
         // when & then
         assertThatThrownBy(() -> applicantAuthService.verifyEmailCode(request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.INVALID_VERIFICATION_CODE.defaultMessage);
 
-        verify(emailVerificationRepository).findAndDeleteCode(email);
+        verify(emailVerificationRepository).findCodeByEmail(email);
+        verify(emailVerificationRepository).incrementAttemptCount(eq(email), any(Duration.class));
+        verify(emailVerificationRepository, never()).deleteCode(anyString());
+        verify(emailVerificationRepository, never()).deleteAttemptCount(anyString());
+        verify(emailVerificationRepository, never()).saveVerifiedToken(anyString(), anyString(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("시도 횟수 한도 초과 시 코드/카운터 소각 후 TOO_MANY_VERIFICATION_ATTEMPTS 예외")
+    public void verifyEmailCode_tooManyAttempts() {
+        // given
+        String email = "user@test.com";
+        ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO(email, "111111");
+
+        when(emailVerificationRepository.findCodeByEmail(email)).thenReturn(Optional.of("999999"));
+        // 최대 5회 -> 6번째 시도부터 차단
+        when(emailVerificationRepository.incrementAttemptCount(eq(email), any(Duration.class))).thenReturn(6L);
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.verifyEmailCode(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.TOO_MANY_VERIFICATION_ATTEMPTS.defaultMessage);
+
+        verify(emailVerificationRepository).deleteCode(email);
+        verify(emailVerificationRepository).deleteAttemptCount(email);
         verify(emailVerificationRepository, never()).saveVerifiedToken(anyString(), anyString(), any(Duration.class));
     }
 


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
구직자(Applicant) 도메인의 회원가입 / 로그인 / 회원탈퇴 + 이메일 인증 시스템을 구현했습니다.
 공용 JWT 인프라를 그대로 활용하고, 구직자 전용 인증 흐름과 도메인 모델을 새로 추가했습니다.      

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

### 1. 이메일 인증 (2단계)                                                                                                                                                       
  - 6자리 코드 (Redis TTL 5분) → 일회성 `verificationToken` (Redis TTL 30분)
  - `GETDEL` 명령으로 코드/토큰을 atomic하게 소비 → 동시 사용 / 재사용 방지        
  - 인증 시도 횟수 5번으로 제약 설정                                                                                          
                                                                                                                                                                                   
  ### 2. 회원가입 (`POST /api/auth/applicants/signup`)                                                                                                                             
  - 비밀번호 정책: 영문 + 숫자 + 특수문자 (8~64자, `@Pattern`)                                                                                                           
  - 필수 약관 5종 + 선택 약관 1종 (마케팅) — 별도 엔티티(`ApplicantAgreement`)에 영구 저장                                                                                         
  - 토큰 검증 직후 atomic burn → 가입 시도 중 동시 요청 차단                                                                                                                       
  - DB unique 제약 + 명시적 `flush()`로 race condition 시 `EMAIL_ALREADY_EXISTS` 변환                                                                                              
                                                                                                                                                                                   
  ### 3. 로그인 (`POST /api/auth/applicants/login`)                                                                                                                                
  - `findByEmailAndDeletedFalse`로 탈퇴 회원 제외                                                                                                                                  
  - AccessToken은 응답 body, RefreshToken은 HttpOnly 쿠키                                                                                                                          
                                                                                                                                                                                   
  ### 4. 회원탈퇴 (`DELETE /api/auth/applicants/me`)                                                                                                                               
  - Soft delete (`deleted = true`, `deletedAt`) + Redis RefreshToken 삭제                                                                                                          
  - RefreshToken 쿠키 만료 헤더 부착                                                                                                                                               
                                                                                                                                                                                   
  ### 5. 보안 정책 강화                                                                                                                                                            
  - `SecurityConfig`: `anyRequest().permitAll()` → `anyRequest().authenticated()`                                                                                                  
  - `WhiteListConfig`로 공개 경로를 그룹별(swagger / server / auth / applicantAuth)로 분리                                                                                         
                                                                                                                                                                                   
  ### 6. 메일 인프라                                                                                                                                                               
  - `MailSender` 인터페이스 + 로컬용 `LoggingMailSender` 구현                                                                                                                      
  - prod 구현체는 추후 추가 예정                                                                                                                                                   
                                                                                                                                                                                   
  ### 7. 테스트 29개 (전부 통과)                                                                                                                                                   
  - 서비스 단위 17개 (Mockito)                                                                                                                                                     
  - 컨트롤러 슬라이스 12개 (`@WebMvcTest`)                                                                                                                                         
  - race condition / atomic 소비 / 검증 순서 등 핵심 동작을 명시적으로 검증           


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
추후 배포 전 `JavaMailSender` 또는 SendGrid 연동 추가 예정
다음 이슈에서 Swagger 문서화 작업과 JWT토큰 보완 작업 예정입니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #27 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)