### PR TITLE
[FEATURE] 검증 로직 변경 및 테스트 코드 수정

### DIFF
--- a/src/main/java/com/weiver/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/weiver/applicant/controller/ApplicantController.java
@@ -10,6 +10,7 @@ import com.weiver.applicant.service.*;
 import com.weiver.global.common.ApiResponse;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
+import com.weiver.global.security.principal.AuthenticatedPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -21,8 +22,6 @@ import org.springframework.web.multipart.MultipartFile;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import java.security.Principal;
 
 @Tag(name = "구직자(Applicant) 도메인 API", description = "구직자의 프로필, 학력, 수상, 자격증, 경력 정보를 관리하는 API입니다.\n\n" +
         "**[필독: PUT(수정) API 데이터 전송 규칙]**\n" +
@@ -48,9 +47,10 @@ public class ApplicantController {
     )
     @GetMapping
     public ResponseEntity<ApiResponse<ApplicantInfoResponseDTO>> searchApplicant(
-            @Parameter(hidden = true) Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        ApplicantInfoResponseDTO responseDTO = applicantService.searchApplicant(principal.getName());
+        ApplicantInfoResponseDTO responseDTO = applicantService.searchApplicant(principal.publicId());
 
         return ResponseEntity.ok(ApiResponse.success(responseDTO));
 
@@ -67,9 +67,10 @@ public class ApplicantController {
     public ResponseEntity<ApiResponse<Void>> updateApplicantInfo(
             @Parameter(description = "개인정보 수정 데이터 (JSON)") @RequestPart(value = "requestDTO") @Valid ApplicantInfoRequestDTO requestDTO,
             @Parameter(description = "프로필 이미지 파일 (.jpg, .png 등)") @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
-            @AuthenticationPrincipal Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        applicantService.updateApplicantInfo(principal.getName(), requestDTO, profileImage);
+        applicantService.updateApplicantInfo(principal.publicId(), requestDTO, profileImage);
 
         return ResponseEntity.ok(ApiResponse.success("개인정보 저장에 성공했습니다."));
     }
@@ -81,9 +82,10 @@ public class ApplicantController {
     @PostMapping("/education")
     public ResponseEntity<ApiResponse<Void>> saveEducationInfo(
             @RequestBody @Valid EducationRequestDTO requestDTO,
-            @Parameter(hidden = true) Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        educationService.saveEducationInfo(principal.getName(), requestDTO);
+        educationService.saveEducationInfo(principal.publicId(), requestDTO);
 
         return ResponseEntity.ok(ApiResponse.success("학력 저장에 성공했습니다."));
     }
@@ -96,9 +98,10 @@ public class ApplicantController {
     @PutMapping("/education")
     public ResponseEntity<ApiResponse<Void>> updateEducationInfo(
             @RequestBody @Valid EducationUpdateRequestDTO requestDTO,
-            @Parameter(hidden = true) Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        educationService.updateEducationInfo(principal.getName(), requestDTO);
+        educationService.updateEducationInfo(principal.publicId(), requestDTO);
 
         return ResponseEntity.ok(ApiResponse.success("학력 업데이트 성공했습니다."));
     }
@@ -110,9 +113,10 @@ public class ApplicantController {
     @PostMapping("/award")
     public ResponseEntity<ApiResponse<Void>> saveAwardInfo(
             @RequestBody @Valid AwardRequestDTO requestDTO,
-            @Parameter(hidden = true) Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        awardService.saveAwardInfo(principal.getName(), requestDTO);
+        awardService.saveAwardInfo(principal.publicId(), requestDTO);
 
         return ResponseEntity.ok(ApiResponse.success("수상이력 저장에 성공했습니다."));
     }
@@ -125,9 +129,10 @@ public class ApplicantController {
     @PutMapping("/award")
     public ResponseEntity<ApiResponse<Void>> updateAwardInfo(
             @RequestBody @Valid AwardUpdateRequestDTO requestDTO,
-            @Parameter(hidden = true) Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        awardService.updateAwardInfo(principal.getName(), requestDTO);
+        awardService.updateAwardInfo(principal.publicId(), requestDTO);
 
         return ResponseEntity.ok(ApiResponse.success("수상목록 업데이트 성공했습니다."));
     }
@@ -139,9 +144,10 @@ public class ApplicantController {
     @PostMapping("/certificate")
     public ResponseEntity<ApiResponse<Void>> saveCertificateInfo(
             @RequestBody @Valid CertificateRequestDTO requestDTO,
-            @Parameter(hidden = true) Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        certificateService.saveCertificateInfo(principal.getName(), requestDTO);
+        certificateService.saveCertificateInfo(principal.publicId(), requestDTO);
 
         return ResponseEntity.ok(ApiResponse.success("자격증 저장에 성공했습니다."));
     }
@@ -154,9 +160,10 @@ public class ApplicantController {
     @PutMapping("/certificate")
     public ResponseEntity<ApiResponse<Void>> updateCertificateInfo(
             @RequestBody @Valid CertificateUpdateRequestDTO requestDTO,
-            @Parameter(hidden = true) Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        certificateService.updateCertificateInfo(principal.getName(), requestDTO);
+        certificateService.updateCertificateInfo(principal.publicId(), requestDTO);
 
         return ResponseEntity.ok(ApiResponse.success("자격증 목록 업데이트 성공했습니다."));
     }
@@ -168,9 +175,10 @@ public class ApplicantController {
     @PostMapping("/experience")
     public ResponseEntity<ApiResponse<Void>> saveWorkExperienceInfo(
             @RequestBody @Valid WorkExperienceRequestDTO requestDTO,
-            @Parameter(hidden = true) Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        workExperienceService.saveWorkExperienceInfo(principal.getName(), requestDTO);
+        workExperienceService.saveWorkExperienceInfo(principal.publicId(), requestDTO);
 
         return ResponseEntity.ok(ApiResponse.success("경력 저장에 성공했습니다."));
     }
@@ -183,9 +191,10 @@ public class ApplicantController {
     @PutMapping("/experience")
     public ResponseEntity<ApiResponse<Void>> updateExperienceInfo(
             @RequestBody @Valid WorkExperienceUpdateRequestDTO requestDTO,
-            @Parameter(hidden = true) Principal principal) {
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        workExperienceService.updateWorkExperienceInfo(principal.getName(), requestDTO);
+        workExperienceService.updateWorkExperienceInfo(principal.publicId(), requestDTO);
 
         return ResponseEntity.ok(ApiResponse.success("경력 업데이트 성공했습니다."));
     }

--- a/src/main/java/com/weiver/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/weiver/applicant/controller/ApplicantController.java
@@ -47,7 +47,7 @@ public class ApplicantController {
     )
     @GetMapping
     public ResponseEntity<ApiResponse<ApplicantInfoResponseDTO>> searchApplicant(
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         ApplicantInfoResponseDTO responseDTO = applicantService.searchApplicant(principal.publicId());
@@ -82,7 +82,7 @@ public class ApplicantController {
     @PostMapping("/education")
     public ResponseEntity<ApiResponse<Void>> saveEducationInfo(
             @RequestBody @Valid EducationRequestDTO requestDTO,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         educationService.saveEducationInfo(principal.publicId(), requestDTO);
@@ -98,7 +98,7 @@ public class ApplicantController {
     @PutMapping("/education")
     public ResponseEntity<ApiResponse<Void>> updateEducationInfo(
             @RequestBody @Valid EducationUpdateRequestDTO requestDTO,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         educationService.updateEducationInfo(principal.publicId(), requestDTO);
@@ -113,7 +113,7 @@ public class ApplicantController {
     @PostMapping("/award")
     public ResponseEntity<ApiResponse<Void>> saveAwardInfo(
             @RequestBody @Valid AwardRequestDTO requestDTO,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         awardService.saveAwardInfo(principal.publicId(), requestDTO);
@@ -129,7 +129,7 @@ public class ApplicantController {
     @PutMapping("/award")
     public ResponseEntity<ApiResponse<Void>> updateAwardInfo(
             @RequestBody @Valid AwardUpdateRequestDTO requestDTO,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         awardService.updateAwardInfo(principal.publicId(), requestDTO);
@@ -144,7 +144,7 @@ public class ApplicantController {
     @PostMapping("/certificate")
     public ResponseEntity<ApiResponse<Void>> saveCertificateInfo(
             @RequestBody @Valid CertificateRequestDTO requestDTO,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         certificateService.saveCertificateInfo(principal.publicId(), requestDTO);
@@ -160,7 +160,7 @@ public class ApplicantController {
     @PutMapping("/certificate")
     public ResponseEntity<ApiResponse<Void>> updateCertificateInfo(
             @RequestBody @Valid CertificateUpdateRequestDTO requestDTO,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         certificateService.updateCertificateInfo(principal.publicId(), requestDTO);
@@ -175,7 +175,7 @@ public class ApplicantController {
     @PostMapping("/experience")
     public ResponseEntity<ApiResponse<Void>> saveWorkExperienceInfo(
             @RequestBody @Valid WorkExperienceRequestDTO requestDTO,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         workExperienceService.saveWorkExperienceInfo(principal.publicId(), requestDTO);
@@ -191,7 +191,7 @@ public class ApplicantController {
     @PutMapping("/experience")
     public ResponseEntity<ApiResponse<Void>> updateExperienceInfo(
             @RequestBody @Valid WorkExperienceUpdateRequestDTO requestDTO,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         workExperienceService.updateWorkExperienceInfo(principal.publicId(), requestDTO);

--- a/src/main/java/com/weiver/essay/controller/EssayAnswerController.java
+++ b/src/main/java/com/weiver/essay/controller/EssayAnswerController.java
@@ -7,15 +7,15 @@ import com.weiver.essay.service.EssayAnswerService;
 import com.weiver.global.common.ApiResponse;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
+import com.weiver.global.security.principal.AuthenticatedPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.security.Principal;
 
 @Tag(name = "자기소개서(Essay) API", description = "구직자의 자기소개서 조회, 저장 및 수정 API입니다.")
 @RestController
@@ -33,10 +33,10 @@ public class EssayAnswerController {
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> saveEssayanswer(
             @RequestBody @Valid EssayAnswerRequestDTO requestDTO,
-            @Parameter(hidden = true) Principal principal) {
-        Long applicantId = extractedId(principal);
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        essayAnswerService.saveEssayAnswer(requestDTO, applicantId);
+        essayAnswerService.saveEssayAnswer(requestDTO, principal.publicId());
         return ResponseEntity.ok(ApiResponse.success("자기소개서 저장 성공했습니다."));
     }
 
@@ -49,10 +49,10 @@ public class EssayAnswerController {
     public ResponseEntity<ApiResponse<Void>> updateEssayanswer(
             @RequestBody @Valid EssayAnswerUpdateRequestDTO requestDTO,
             @Parameter(description = "수정할 자기소개서의 고유 ID (PK)", example = "1") @PathVariable long answerId,
-            @Parameter(hidden = true) Principal principal) {
-        Long applicantId = extractedId(principal);
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        essayAnswerService.updateEssayAnswer(requestDTO, applicantId, answerId);
+        essayAnswerService.updateEssayAnswer(requestDTO, principal.publicId(), answerId);
 
         return ResponseEntity.ok(ApiResponse.success("자기소개서 수정 성공했습니다."));
     }
@@ -63,22 +63,11 @@ public class EssayAnswerController {
     )
     @GetMapping
     public ResponseEntity<ApiResponse<EssayAnswerResponseDTO>> searchEssayanswer(
-            @Parameter(hidden = true) Principal principal) {
-        Long applicantId = extractedId(principal);
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        EssayAnswerResponseDTO responseDTO = essayAnswerService.searchEssayAnswer(applicantId);
+        EssayAnswerResponseDTO responseDTO = essayAnswerService.searchEssayAnswer(principal.publicId());
 
         return ResponseEntity.ok(ApiResponse.success(responseDTO));
-    }
-
-    /**
-     * 편의 메소드
-     * */
-    private static Long extractedId(Principal principal) {
-        if(principal == null){
-            throw new BusinessException(ErrorCode.UNAUTHORIZED);
-        }
-
-        return Long.parseLong(principal.getName());
     }
 }

--- a/src/main/java/com/weiver/essay/controller/EssayAnswerController.java
+++ b/src/main/java/com/weiver/essay/controller/EssayAnswerController.java
@@ -33,7 +33,7 @@ public class EssayAnswerController {
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> saveEssayanswer(
             @RequestBody @Valid EssayAnswerRequestDTO requestDTO,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         essayAnswerService.saveEssayAnswer(requestDTO, principal.publicId());
@@ -49,7 +49,7 @@ public class EssayAnswerController {
     public ResponseEntity<ApiResponse<Void>> updateEssayanswer(
             @RequestBody @Valid EssayAnswerUpdateRequestDTO requestDTO,
             @Parameter(description = "수정할 자기소개서의 고유 ID (PK)", example = "1") @PathVariable long answerId,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         essayAnswerService.updateEssayAnswer(requestDTO, principal.publicId(), answerId);
@@ -63,7 +63,7 @@ public class EssayAnswerController {
     )
     @GetMapping
     public ResponseEntity<ApiResponse<EssayAnswerResponseDTO>> searchEssayanswer(
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         EssayAnswerResponseDTO responseDTO = essayAnswerService.searchEssayAnswer(principal.publicId());

--- a/src/main/java/com/weiver/essay/service/EssayAnswerService.java
+++ b/src/main/java/com/weiver/essay/service/EssayAnswerService.java
@@ -23,19 +23,19 @@ public class EssayAnswerService {
     private final ApplicantRepository applicantRepository;
 
 
-    public void saveEssayAnswer(EssayAnswerRequestDTO requestDTO, long applicantId) {
-        Applicant applicant = getApplicant(applicantId);
+    public void saveEssayAnswer(EssayAnswerRequestDTO requestDTO, String publicId) {
+        Applicant applicant = getApplicant(publicId);
         EssayAnswer essayAnswer = requestDTO.toEntity(applicant);
 
         essayAnswerRepository.save(essayAnswer);
     }
 
-    public void updateEssayAnswer(EssayAnswerUpdateRequestDTO requestDTO, long applicantId, long answerId) {
+    public void updateEssayAnswer(EssayAnswerUpdateRequestDTO requestDTO, String publicId, long answerId) {
 
         EssayAnswer essayAnswer = essayAnswerRepository.findById(answerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESSAY_ANSWER_NOT_FOUND));
 
-        if (!essayAnswer.getApplicant().getApplicantId().equals(applicantId)) {
+        if (!essayAnswer.getApplicant().getPublicId().equals(publicId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
@@ -45,8 +45,8 @@ public class EssayAnswerService {
     }
 
     @Transactional(readOnly = true)
-    public EssayAnswerResponseDTO searchEssayAnswer(long applicantId) {
-        Applicant applicant = getApplicant(applicantId);
+    public EssayAnswerResponseDTO searchEssayAnswer(String publicId) {
+        Applicant applicant = getApplicant(publicId);
 
         EssayAnswer essayAnswer = essayAnswerRepository.findByApplicant(applicant)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ESSAY_ANSWER_NOT_FOUND));
@@ -55,8 +55,8 @@ public class EssayAnswerService {
         return responseDTO;
     }
 
-    private Applicant getApplicant(long applicantId) {
-        Applicant applicant = applicantRepository.findById(applicantId)
+    private Applicant getApplicant(String publicId) {
+        Applicant applicant = applicantRepository.findByPublicId(publicId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
         return applicant;
     }

--- a/src/main/java/com/weiver/jobposting/controller/JobPostingController.java
+++ b/src/main/java/com/weiver/jobposting/controller/JobPostingController.java
@@ -51,7 +51,7 @@ public class JobPostingController {
             @Parameter(description = "임시 저장 여부 (기본값 : false) ")
             @RequestParam(value = "isTemp", defaultValue = "false") boolean isTemp,
 
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
 
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
@@ -75,7 +75,7 @@ public class JobPostingController {
             @Parameter(description = "새로 변경할 배너 이미지 파일 (선택)", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
             @RequestPart(value = "emailBannerImage", required = false) MultipartFile emailBannerImage,
 
-            @AuthenticationPrincipal AuthenticatedPrincipal principal,
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal,
 
             @Parameter(description = "수정할 공고의 고유 ID(jdId)", example = "1")
             @PathVariable Long jdId){
@@ -102,7 +102,7 @@ public class JobPostingController {
             @Parameter(description = "페이지당 데이터 개수", example = "3")
             @RequestParam(defaultValue = "3") int size,
 
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
 
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
@@ -116,7 +116,7 @@ public class JobPostingController {
     )
     @GetMapping("/{jdId}")
     public ResponseEntity<ApiResponse<JobPostingResponseDTO>> getJobPosting(
-            @AuthenticationPrincipal AuthenticatedPrincipal principal,
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal,
             @Parameter(description = "조회할 공고의 고유 ID", example = "1")
             @PathVariable Long jdId){
 

--- a/src/main/java/com/weiver/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/weiver/portfolio/controller/PortfolioController.java
@@ -3,6 +3,7 @@ package com.weiver.portfolio.controller;
 import com.weiver.global.common.ApiResponse;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
+import com.weiver.global.security.principal.AuthenticatedPrincipal;
 import com.weiver.portfolio.dto.request.PortfolioRequestDTO;
 import com.weiver.portfolio.dto.request.PortfolioUpdateRequestDTO;
 import com.weiver.portfolio.dto.response.PortfolioResponseDTO;
@@ -14,10 +15,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.security.Principal;
 
 @Tag(name = "포트폴리오(Portfolio) API", description = "구직자의 포트폴리오 파일(PDF 등) 및 외부 링크 저장/조회 API입니다.")
 @RestController
@@ -38,10 +38,10 @@ public class PortfolioController {
     public ResponseEntity<ApiResponse<Void>> savePortfolio(
             @Parameter(description = "포트폴리오 텍스트 데이터 (JSON)") @RequestPart(value = "requestDTO") @Valid PortfolioRequestDTO requestDTO,
             @Parameter(description = "포트폴리오 첨부 파일 (.pdf, .zip 등)") @RequestPart(value = "portfolio", required = false) MultipartFile portfolio,
-            @Parameter(hidden = true) Principal principal) {
-        Long applicantId = extractedId(principal);
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        portfolioService.savePortfolio(requestDTO, portfolio, applicantId);
+        portfolioService.savePortfolio(requestDTO, portfolio, principal.publicId());
 
         return ResponseEntity.ok(ApiResponse.success("포트폴리오 저장 완료됐습니다."));
     }
@@ -57,10 +57,10 @@ public class PortfolioController {
             @Parameter(description = "수정할 텍스트 데이터 (JSON)") @RequestPart(value = "requestDTO") @Valid PortfolioUpdateRequestDTO requestDTO,
             @Parameter(description = "새로 등록할 포트폴리오 첨부 파일 (선택)") @RequestPart(value = "portfolio", required = false) MultipartFile portfolio,
             @Parameter(description = "수정할 포트폴리오의 고유 ID", example = "1") @PathVariable Long portfolioId,
-            @Parameter(hidden = true) Principal principal) {
-        Long applicantId = extractedId(principal);
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        portfolioService.updatePortfolio(requestDTO, portfolio, applicantId, portfolioId);
+        portfolioService.updatePortfolio(requestDTO, portfolio, principal.publicId(), portfolioId);
         
         return ResponseEntity.ok(ApiResponse.success("포트폴리오 수정 완료됐습니다."));
     }
@@ -73,23 +73,11 @@ public class PortfolioController {
     )
     @GetMapping
     public ResponseEntity<ApiResponse<PortfolioResponseDTO>> searchPortfolio(
-            @Parameter(hidden = true) Principal principal) {
-        Long applicantId = extractedId(principal);
+            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
-        PortfolioResponseDTO responseDTO = portfolioService.searchPortfolio(applicantId);
+        PortfolioResponseDTO responseDTO = portfolioService.searchPortfolio(principal.publicId());
 
         return ResponseEntity.ok(ApiResponse.success(responseDTO));
-    }
-
-
-    /**
-     * 편의 메소드
-     * */
-    private static Long extractedId(Principal principal) {
-        if(principal == null){
-            throw new BusinessException(ErrorCode.UNAUTHORIZED);
-        }
-
-        return Long.parseLong(principal.getName());
     }
 }

--- a/src/main/java/com/weiver/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/weiver/portfolio/controller/PortfolioController.java
@@ -38,7 +38,7 @@ public class PortfolioController {
     public ResponseEntity<ApiResponse<Void>> savePortfolio(
             @Parameter(description = "포트폴리오 텍스트 데이터 (JSON)") @RequestPart(value = "requestDTO") @Valid PortfolioRequestDTO requestDTO,
             @Parameter(description = "포트폴리오 첨부 파일 (.pdf, .zip 등)") @RequestPart(value = "portfolio", required = false) MultipartFile portfolio,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         portfolioService.savePortfolio(requestDTO, portfolio, principal.publicId());
@@ -57,7 +57,7 @@ public class PortfolioController {
             @Parameter(description = "수정할 텍스트 데이터 (JSON)") @RequestPart(value = "requestDTO") @Valid PortfolioUpdateRequestDTO requestDTO,
             @Parameter(description = "새로 등록할 포트폴리오 첨부 파일 (선택)") @RequestPart(value = "portfolio", required = false) MultipartFile portfolio,
             @Parameter(description = "수정할 포트폴리오의 고유 ID", example = "1") @PathVariable Long portfolioId,
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         portfolioService.updatePortfolio(requestDTO, portfolio, principal.publicId(), portfolioId);
@@ -73,7 +73,7 @@ public class PortfolioController {
     )
     @GetMapping
     public ResponseEntity<ApiResponse<PortfolioResponseDTO>> searchPortfolio(
-            @AuthenticationPrincipal AuthenticatedPrincipal principal) {
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
 
         PortfolioResponseDTO responseDTO = portfolioService.searchPortfolio(principal.publicId());

--- a/src/main/java/com/weiver/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/weiver/portfolio/service/PortfolioService.java
@@ -25,14 +25,14 @@ public class PortfolioService {
     private ApplicantRepository applicantRepository;
     private S3Service s3Service;
 
-    public void savePortfolio(PortfolioRequestDTO requestDTO, MultipartFile file, long applicantId) {
+    public void savePortfolio(PortfolioRequestDTO requestDTO, MultipartFile file, String publicId) {
         String fileName = file.getOriginalFilename() != null ? file.getOriginalFilename() : "";
         Long fileSize = file.getSize();
         String fileType = org.springframework.util.StringUtils.getFilenameExtension(fileName);
 
         String fileKey = s3Service.privateUpload(file, "portfolios");
 
-        Applicant applicant = getApplicant(applicantId);
+        Applicant applicant = getApplicant(publicId);
         Portfolio portfolio = requestDTO.toEntity(applicant, fileSize, fileName, fileType, fileKey);
 
         portfolioRepository.save(portfolio);
@@ -40,13 +40,13 @@ public class PortfolioService {
 
 
     public void updatePortfolio(PortfolioUpdateRequestDTO requestDTO, MultipartFile file,
-                                long applicantId, long portfolioId) {
+                                String publicId, long portfolioId) {
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PORTFOLIO_NOT_FOUND));
 
         String fileKey = portfolio.getFileKey();
 
-        if(!portfolio.getApplicant().getApplicantId().equals(applicantId)){
+        if(!portfolio.getApplicant().getPublicId().equals(publicId)){
             throw new BusinessException(ErrorCode.PORTFOLIO_NOT_FOUND);
         }
 
@@ -68,8 +68,8 @@ public class PortfolioService {
     }
 
     @Transactional(readOnly = true)
-    public PortfolioResponseDTO searchPortfolio(long applicantId) {
-        Applicant applicant = getApplicant(applicantId);
+    public PortfolioResponseDTO searchPortfolio(String publicId) {
+        Applicant applicant = getApplicant(publicId);
 
         Portfolio portfolio = portfolioRepository.findByApplicant(applicant)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PORTFOLIO_NOT_FOUND));
@@ -80,8 +80,8 @@ public class PortfolioService {
         return responseDTO;
     }
 
-    private Applicant getApplicant(long applicantId) {
-        Applicant applicant = applicantRepository.findById(applicantId)
+    private Applicant getApplicant(String publicId) {
+        Applicant applicant = applicantRepository.findByPublicId(publicId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
         return applicant;
     }

--- a/src/test/java/com/weiver/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/weiver/applicant/controller/ApplicantControllerTest.java
@@ -10,6 +10,7 @@ import com.weiver.global.security.cookie.CookieProvider;
 import com.weiver.global.security.jwt.JwtAuthenticationFilter;
 import com.weiver.global.security.jwt.JwtTokenProvider;
 import com.weiver.global.security.principal.AuthenticatedPrincipal;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -37,7 +39,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication; // 💡 핵심 임포트!
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -72,12 +73,19 @@ class ApplicantControllerTest {
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private RequestPostProcessor customAuth(String publicId) {
-        AuthenticatedPrincipal principal = new AuthenticatedPrincipal(publicId, UserRole.APPLICANT);
+        return request -> {
+            AuthenticatedPrincipal principal = new AuthenticatedPrincipal(publicId, UserRole.APPLICANT);
+            Authentication auth = new UsernamePasswordAuthenticationToken(
+                    principal, null, List.of(new SimpleGrantedAuthority("ROLE_APPLICANT")));
 
-        Authentication auth = new UsernamePasswordAuthenticationToken(
-                principal, null, List.of(new SimpleGrantedAuthority("ROLE_APPLICANT")));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            return request;
+        };
+    }
 
-        return authentication(auth);
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -122,7 +130,7 @@ class ApplicantControllerTest {
 
         // when, then
         mockMvc.perform(get("/applicants")
-                        .with(customAuth("2222"))
+                        .with(customAuth("2222")) // ⬅️ 변경: 찰떡같이 붙는 커스텀 인증!
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -154,7 +162,7 @@ class ApplicantControllerTest {
                             request.setMethod(HttpMethod.PUT.name());
                             return request;
                         })
-                        .with(customAuth("2222"))
+                        .with(customAuth("2222")) // ⬅️ 변경!
                 )
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -165,6 +173,9 @@ class ApplicantControllerTest {
     @Test
     @DisplayName("엣지 케이스 : Principal이 없을 대 UNAUTHORIZED 에러 발생")
     void searchApplicant_WithoutPrincipal_ThrowsUnauthorized() throws Exception {
+        // [주의] addFilters = false 상태에서 커스텀 객체를 안 주입하면
+        // 컨트롤러의 파라미터가 아예 null이 됩니다.
+        // 컨트롤러에서 `if(principal == null) throw UNAUTHORIZED;` 처리가 되어있어야 통과합니다!
         mockMvc.perform(get("/applicants")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -184,7 +195,7 @@ class ApplicantControllerTest {
 
         // when, then
         mockMvc.perform(put("/applicants/award")
-                        .with(customAuth("1"))
+                        .with(customAuth("1")) // ⬅️ 변경!
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestDtoJson))
                 .andDo(print())
@@ -216,7 +227,7 @@ class ApplicantControllerTest {
                             request.setMethod(HttpMethod.PUT.name());
                             return request;
                         })
-                        .with(customAuth("2222")))
+                        .with(customAuth("2222"))) // ⬅️ 변경!
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("success"));
@@ -242,7 +253,7 @@ class ApplicantControllerTest {
                             request.setMethod(HttpMethod.PUT.name());
                             return request;
                         })
-                        .with(customAuth("1")))
+                        .with(customAuth("1"))) // ⬅️ 변경!
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value("error"));
@@ -278,7 +289,7 @@ class ApplicantControllerTest {
                             request.setMethod(HttpMethod.PUT.name());
                             return request;
                         })
-                        .with(customAuth("2222")))
+                        .with(customAuth("2222"))) // ⬅️ 변경!
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("지원하지 않는 파일 형식입니다."));

--- a/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
+++ b/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class EssayAnswerServiceImplTest {
+class EssayAnswerServiceTest {
 
     @Mock
     private EssayAnswerRepository essayAnswerRepository;
@@ -42,13 +42,17 @@ class EssayAnswerServiceImplTest {
     void saveEssayAnswer_Success() {
         // Given
         long applicantId = 1L;
-        Applicant applicant = Applicant.builder().applicantId(applicantId).build();
+        String publicId = "3333";
+        Applicant applicant = Applicant.builder()
+                .applicantId(applicantId)
+                .publicId(publicId)
+                .build();
         EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO("안녕. 날 뽑아봐.");
 
-        given(applicantRepository.findById(applicantId)).willReturn(Optional.of(applicant));
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
 
         // When
-        essayAnswerService.saveEssayAnswer(requestDTO, applicantId);
+        essayAnswerService.saveEssayAnswer(requestDTO, publicId);
 
         // Then
         verify(essayAnswerRepository, times(1)).save(any(EssayAnswer.class));
@@ -60,8 +64,12 @@ class EssayAnswerServiceImplTest {
         // Given
         long applicantId = 1L;
         long answerId = 100L;
+        String publicId = "3333";
 
-        Applicant me = Applicant.builder().applicantId(applicantId).build();
+        Applicant me = Applicant.builder()
+                .applicantId(applicantId)
+                .publicId(publicId)
+                .build();
 
         EssayAnswer myEssay = EssayAnswer.builder()
                 .answerId(answerId)
@@ -74,7 +82,7 @@ class EssayAnswerServiceImplTest {
         given(essayAnswerRepository.findById(answerId)).willReturn(Optional.of(myEssay));
 
         // When
-        essayAnswerService.updateEssayAnswer(updateDTO, applicantId, answerId);
+        essayAnswerService.updateEssayAnswer(updateDTO, publicId, answerId);
 
         // Then
         assertThat(myEssay.getAnswer()).isEqualTo("안녕, 나 수정했어.");
@@ -85,10 +93,14 @@ class EssayAnswerServiceImplTest {
     void updateEssayAnswer_Forbidden_ThrowsException() {
         // Given
         long myApplicantId = 1L;
-        long hackerApplicantId = 2L; //  공격자 ID
+        String myPublicId = "3333";
+        String hackerPublicId = "2222";
         long answerId = 100L;
 
-        Applicant me = Applicant.builder().applicantId(myApplicantId).build();
+        Applicant me = Applicant.builder()
+                .applicantId(myApplicantId)
+                .publicId(myPublicId)
+                .build();
 
         // 진짜 주인이 있는 자소서 객체 생성
         EssayAnswer myEssay = EssayAnswer.builder()
@@ -102,7 +114,7 @@ class EssayAnswerServiceImplTest {
         given(essayAnswerRepository.findById(answerId)).willReturn(Optional.of(myEssay));
 
         // When & Then
-        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswer(updateDTO, hackerApplicantId, answerId))
+        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswer(updateDTO, hackerPublicId, answerId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(ErrorCode.FORBIDDEN);
@@ -113,7 +125,11 @@ class EssayAnswerServiceImplTest {
     void searchEssayAnswer_Success() {
         // Given
         long applicantId = 1L;
-        Applicant applicant = Applicant.builder().applicantId(applicantId).build();
+        String publicId = "3333";
+        Applicant applicant = Applicant.builder()
+                .applicantId(applicantId)
+                .publicId(publicId)
+                .build();
 
         EssayAnswer essayAnswer = EssayAnswer.builder()
                 .answerId(10L)
@@ -121,11 +137,11 @@ class EssayAnswerServiceImplTest {
                 .applicant(applicant)
                 .build();
 
-        given(applicantRepository.findById(applicantId)).willReturn(Optional.of(applicant));
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
         given(essayAnswerRepository.findByApplicant(applicant)).willReturn(Optional.of(essayAnswer));
 
         // When
-        EssayAnswerResponseDTO responseDTO = essayAnswerService.searchEssayAnswer(applicantId);
+        EssayAnswerResponseDTO responseDTO = essayAnswerService.searchEssayAnswer(publicId);
 
         // Then
         assertThat(responseDTO.answer()).isEqualTo("이것은 내 자소서입니다.");
@@ -135,13 +151,13 @@ class EssayAnswerServiceImplTest {
     @DisplayName("엣지 케이스: 존재하지 않는 회원의 ID로 자소서 저장 시 APPLICANT_NOT_FOUND 예외 발생")
     void saveEssayAnswer_ApplicantNotFound_ThrowsException() {
         // Given
-        long invalidApplicantId = 999L; // DB에 없는 유령 회원
+        String invalidPublicId = "2222";
         EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO("지원 동기입니다.");
 
-        given(applicantRepository.findById(invalidApplicantId)).willReturn(Optional.empty());
+        given(applicantRepository.findByPublicId(invalidPublicId)).willReturn(Optional.empty());
 
         // When & Then!
-        assertThatThrownBy(() -> essayAnswerService.saveEssayAnswer(requestDTO, invalidApplicantId))
+        assertThatThrownBy(() -> essayAnswerService.saveEssayAnswer(requestDTO, invalidPublicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(ErrorCode.APPLICANT_NOT_FOUND);
@@ -151,14 +167,14 @@ class EssayAnswerServiceImplTest {
     @DisplayName("엣지 케이스: 존재하지 않는 자소서를 수정하려고 할 때 ESSAY_ANSWER_NOT_FOUND 예외 발생")
     void updateEssayAnswer_EssayNotFound_ThrowsException() {
         // Given
-        long applicantId = 1L;
+        String publicId = "3333";
         long invalidAnswerId = 999L;
         EssayAnswerUpdateRequestDTO updateDTO = new EssayAnswerUpdateRequestDTO("수정할 내용");
 
         given(essayAnswerRepository.findById(invalidAnswerId)).willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswer(updateDTO, applicantId, invalidAnswerId))
+        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswer(updateDTO, publicId, invalidAnswerId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(ErrorCode.ESSAY_ANSWER_NOT_FOUND);
@@ -169,8 +185,12 @@ class EssayAnswerServiceImplTest {
     void updateEssayAnswer_NullContent_KeepsExistingData() {
         // Given
         long applicantId = 1L;
+        String publicId = "3333";
         long answerId = 100L;
-        Applicant me = Applicant.builder().applicantId(applicantId).build();
+        Applicant me = Applicant.builder()
+                .applicantId(applicantId)
+                .publicId(publicId)
+                .build();
 
         // 기존 자소서 내용
         EssayAnswer myEssay = EssayAnswer.builder()
@@ -184,7 +204,7 @@ class EssayAnswerServiceImplTest {
         given(essayAnswerRepository.findById(answerId)).willReturn(Optional.of(myEssay));
 
         // When
-        essayAnswerService.updateEssayAnswer(nullUpdateDTO, applicantId, answerId);
+        essayAnswerService.updateEssayAnswer(nullUpdateDTO, publicId, answerId);
 
         // Then
         assertThat(myEssay.getAnswer()).isEqualTo("내 소중한 기존 자소서 내용");
@@ -196,14 +216,18 @@ class EssayAnswerServiceImplTest {
     void searchEssayAnswer_NotWrittenYet_ThrowsException() {
         // Given
         long applicantId = 1L;
-        Applicant applicant = Applicant.builder().applicantId(applicantId).build();
+        String publicId = "3333";
+        Applicant applicant = Applicant.builder()
+                .applicantId(applicantId)
+                .publicId(publicId)
+                .build();
 
-        given(applicantRepository.findById(applicantId)).willReturn(Optional.of(applicant));
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
 
         given(essayAnswerRepository.findByApplicant(applicant)).willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> essayAnswerService.searchEssayAnswer(applicantId))
+        assertThatThrownBy(() -> essayAnswerService.searchEssayAnswer(publicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(ErrorCode.ESSAY_ANSWER_NOT_FOUND);

--- a/src/test/java/com/weiver/portfolio/service/PortfolioServiceImplTest.java
+++ b/src/test/java/com/weiver/portfolio/service/PortfolioServiceImplTest.java
@@ -43,10 +43,15 @@ class PortfolioServiceImplTest {
     void searchPortfolio_Success() {
         // Given
         long applicantId = 1L;
+        String publicId = "3333";
+
         String originalFileKey = "https://weiver-private-bucket/portfolios/uuid-1234.pdf";
         String mockPresignedUrl = "https://weiver-private-bucket/portfolios/uuid-1234.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...";
 
-        Applicant applicant = Applicant.builder().applicantId(applicantId).build();
+        Applicant applicant = Applicant.builder()
+                .applicantId(applicantId)
+                .publicId(publicId)
+                .build();
 
         Portfolio portfolio = Portfolio.builder()
                 .portfolioId(1L)
@@ -54,7 +59,7 @@ class PortfolioServiceImplTest {
                 .applicant(applicant)
                 .build();
 
-        given(applicantRepository.findById(applicantId))
+        given(applicantRepository.findByPublicId(publicId))
                 .willReturn(Optional.of(applicant));
         given(portfolioRepository.findByApplicant(applicant))
                 .willReturn(Optional.of(portfolio));
@@ -64,7 +69,7 @@ class PortfolioServiceImplTest {
                 .willReturn(mockPresignedUrl);
 
         // When
-        PortfolioResponseDTO responseDTO = portfolioService.searchPortfolio(applicantId);
+        PortfolioResponseDTO responseDTO = portfolioService.searchPortfolio(publicId);
 
         // Then
         verify(s3Service, times(1)).getPresignedUrl(originalFileKey);
@@ -78,16 +83,20 @@ class PortfolioServiceImplTest {
     void searchPortfolio_NotFound_ThrowsException() {
         // Given
         long applicantId = 1L;
-        Applicant applicant = Applicant.builder().applicantId(applicantId).build();
+        String publicId = "3333";
+        Applicant applicant = Applicant.builder()
+                .applicantId(applicantId)
+                .publicId(publicId)
+                .build();
 
-        given(applicantRepository.findById(applicantId))
+        given(applicantRepository.findByPublicId(publicId))
                 .willReturn(Optional.of(applicant));
 
         given(portfolioRepository.findByApplicant(applicant))
                 .willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> portfolioService.searchPortfolio(applicantId))
+        assertThatThrownBy(() -> portfolioService.searchPortfolio(publicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(ErrorCode.PORTFOLIO_NOT_FOUND);
@@ -98,12 +107,13 @@ class PortfolioServiceImplTest {
     void searchPortfolio_ApplicantNotFound_ThrowsException() {
         // Given
         long invalidApplicantId = 999L;
+        String invalidPublicId = "3333";
 
-        given(applicantRepository.findById(invalidApplicantId))
+        given(applicantRepository.findByPublicId(invalidPublicId))
                 .willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> portfolioService.searchPortfolio(invalidApplicantId))
+        assertThatThrownBy(() -> portfolioService.searchPortfolio(invalidPublicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(ErrorCode.APPLICANT_NOT_FOUND);


### PR DESCRIPTION
## 📝 PR 설명
보안 강화 및 식별자 은닉을 위해, 기존 API와 내부 비즈니스 로직에서 사용되던 내부 DB PK(applicantId)를 publicId 기반의 인증 및 식별 로직으로 전면 개편했습니다.

이를 위해 Spring Security의 인증 필터를 거쳐 생성되는 커스텀 객체인 AuthenticatedPrincipal을 도입하였으며, 각 컨트롤러에서 @AuthenticationPrincipal을 통해 안전하게 publicId를 추출하여 서비스 레이어로 전달하도록 아키텍처를 개선했습니다.

## 📝 Summary
#### 1. 포트폴리오 내부 로직 변경 (applicantId -> publicId 파라미터 및 조회 로직 수정)

#### 2. 자기소개서 내부 로직 변경 (applicantId -> publicId 파라미터 및 조회 로직 수정)

#### 3. 구직자 내부 로직 변경 (applicantId -> publicId 파라미터 및 조회 로직 수정)

#### 4. Spring Security 커스텀 인증 적용

AuthenticatedPrincipal Record(publicId, role) 도입

API 엔드포인트에 @AuthenticationPrincipal AuthenticatedPrincipal principal 적용 및 null 방어 로직(401 UNAUTHORIZED) 추가

#### 5. Test 코드 전면 리팩토링

필터가 비활성화된 @WebMvcTest 환경에서도 완벽하게 동작하도록 SecurityContext에 직접 커스텀 인증 객체를 주입하는 customAuth() 헬퍼 메서드 구현 및 적용

## 🙏 Question & PR point
### 1. 테스트 코드 작성 시 인증 객체 주입 방법 변경
이번 PR 이후로 컨트롤러 테스트를 작성할 때, 기존의 얕은 모킹 방식(.principal())을 사용하면 NPE가 발생합니다.

테스트 코드 내부에 구현해 둔 customAuth메서드를 활용하여 .with(customAuth("2222")) 형태로 시큐리티 컨텍스트에 직접 인증 객체를 꽂아주셔야 합니다. (특히 multipart 요청 테스트 시 필수입니다.)

### 2. 누락된 기존 ID 참조 확인 요청
구직자(Applicant), 포트폴리오, 자기소개서 도메인의 컨트롤러와 서비스 레이어 파라미터를 publicId로 모두 변경했습니다. 혹시 리뷰하시면서 다른 도메인이나 연관 관계 쪽에 여전히 기존 applicantId를 직접 참조하는 레거시 코드가 남아있는지 한 번 더 크로스 체크 부탁드립니다.


## 📣 Related Issue
close #42 

## 📑 P-n룰 설명
comment남기실 때 P-n규칙 꼭 남겨주세요!
P1: 꼭 반영해주세요 (Request changes)

P2: 적극적으로 고려해주세요 (Request changes)

P3: 웬만하면 반영해 주세요 (Comment)

P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)

P5: 그냥 사소한 의견입니다 (Approve)