### PR TITLE
[Docs] 구직자/공통 인증 API Swagger 문서화 작업

### DIFF
--- a/src/main/java/com/weiver/auth/controller/ApplicantAuthController.java
+++ b/src/main/java/com/weiver/auth/controller/ApplicantAuthController.java
@@ -12,6 +12,10 @@ import com.weiver.auth.service.dto.ApplicantLoginResult;
 import com.weiver.global.common.ApiResponse;
 import com.weiver.global.security.principal.AuthenticatedPrincipal;
 import com.weiver.global.security.cookie.CookieProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "구직자(Applicant) 인증(Auth) API", description = "구직자 이메일 인증, 회원가입, 로그인, 회원탈퇴를 처리하는 API입니다.")
 @RestController
 @RequestMapping("/api/auth/applicants")
 @RequiredArgsConstructor
@@ -29,6 +34,10 @@ public class ApplicantAuthController {
     private final ApplicantAuthService applicantAuthService;
     private final CookieProvider cookieProvider;
 
+    @Operation(
+            summary = "이메일 인증번호 전송",
+            description = "회원가입시 인증에 필요한 코드를 회원의 이메일로 전송합니다."
+    )
     @PostMapping("/email/send")
     public ResponseEntity<ApiResponse<Void>> sendEmailCode(
             @RequestBody
@@ -40,6 +49,11 @@ public class ApplicantAuthController {
         return ResponseEntity.ok(ApiResponse.success(200, null, "이메일 인증번호 전송에 성공했습니다."));
     }
 
+    @Operation(
+            summary = "이메일 인증번호 검증",
+            description = "이메일로 전송된 인증번호를 검증합니다.<br>"+
+                    "인증번호가 일치하면 이메일 인증 성공 결과를 반환합니다."
+    )
     @PostMapping("/email/verify")
     public ResponseEntity<ApiResponse<ApplicantEmailVerifyResponseDTO>> verifyEmailCode(
             @RequestBody
@@ -51,6 +65,11 @@ public class ApplicantAuthController {
         return ResponseEntity.ok(ApiResponse.success(200, responseDTO, "이메일 인증번호 확인에 성공했습니다."));
     }
 
+    @Operation(
+            summary = "회원가입",
+            description = "구직자의 회원가입을 처리합니다.<br>" +
+                    "회원가입 성공 시 생성된 구직자 정보를 반환합니다."
+    )
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<ApplicantSignupResponseDTO>> signup(
             @RequestBody
@@ -62,11 +81,18 @@ public class ApplicantAuthController {
         return ResponseEntity.ok(ApiResponse.success(201, responseDTO, "회원가입에 성공했습니다."));
     }
 
+    @Operation(
+            summary = "로그인",
+            description = "구직자의 이메일과 비밀번호를 검증하여 로그인을 처리합니다.<br>" +
+                    "로그인 성공 시 Access Token과 Role을 응답 body로 반환하고, Refresh Token은 HttpOnly Cookie로 발급합니다."
+    )
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<ApplicantLoginResponseDTO>> login(
             @RequestBody
             @Valid
             ApplicantLoginRequestDTO requestDTO,
+
+            @Parameter(hidden = true)
             HttpServletResponse httpServletResponse
     ) {
         ApplicantLoginResult loginResult = applicantAuthService.login(requestDTO);
@@ -84,9 +110,19 @@ public class ApplicantAuthController {
 
     }
 
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "현재 로그인한 구직자 계정을 탈퇴 처리합니다.<br>" +
+                    "탈퇴 성공 시 저장된 Refresh Token을 삭제하고 Refresh Token Cookie를 즉시 만료시킵니다.<br>" +
+                    "Authorization Header에 Bearer Access Token이 필요합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
     @DeleteMapping("/me")
     public ResponseEntity<ApiResponse<Void>> withdraw(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal AuthenticatedPrincipal principal,
+
+            @Parameter(hidden = true)
             HttpServletResponse httpServletResponse
     ) {
         applicantAuthService.withdraw(principal.publicId());

--- a/src/main/java/com/weiver/auth/controller/AuthController.java
+++ b/src/main/java/com/weiver/auth/controller/AuthController.java
@@ -5,8 +5,7 @@ import com.weiver.auth.dto.response.ReissueResponseDTO;
 import com.weiver.auth.service.AuthService;
 import com.weiver.auth.service.dto.TokenReissueResult;
 import com.weiver.global.common.ApiResponse;
-import com.weiver.global.exception.BusinessException;
-import com.weiver.global.exception.ErrorCode;
+
 import com.weiver.global.security.cookie.CookieProvider;
 import com.weiver.global.security.cookie.RefreshTokenCookieResolver;
 import com.weiver.global.security.jwt.BearerTokenResolver;

--- a/src/main/java/com/weiver/auth/controller/AuthController.java
+++ b/src/main/java/com/weiver/auth/controller/AuthController.java
@@ -10,6 +10,10 @@ import com.weiver.global.exception.ErrorCode;
 import com.weiver.global.security.cookie.CookieProvider;
 import com.weiver.global.security.cookie.RefreshTokenCookieResolver;
 import com.weiver.global.security.jwt.BearerTokenResolver;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "통합 계정 관리에 사용되는 인증(auth) API", description = "구직자, 기업 관리자가 사용하는 로그아웃, JWT 토큰 재발급, CSRF 토큰 발급을 처리하는 인증 API 입니다.")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -29,11 +34,15 @@ public class AuthController {
     private final BearerTokenResolver bearerTokenResolver;
     private final RefreshTokenCookieResolver refreshTokenCookieResolver;
 
+    @Operation(summary = "로그아웃")
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
+            @Parameter(hidden = true)
             @RequestHeader(HttpHeaders.AUTHORIZATION)
             String authorizationHeader,
 
+            @Parameter(hidden = true)
             HttpServletResponse response
     ) {
         String accessToken = bearerTokenResolver.resolve(authorizationHeader);
@@ -50,9 +59,17 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success("로그아웃에 성공했습니다."));
     }
 
+    @Operation(
+            summary = "AccessToken 재발급",
+            description = "요청 Cookie에 포함된 RefreshToken을 이용하여 AccessToken을 재발급합니다.<br>" +
+                    "재발급 성공 시 새로운 RefreshToken은 Set-Cookie Header로 내려가며, AccessToken은 응답 Body로 반환됩니다."
+    )
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<ReissueResponseDTO>> reissue(
+            @Parameter(hidden = true)
             HttpServletRequest request,
+
+            @Parameter(hidden = true)
             HttpServletResponse response
     ) {
         String refreshToken = refreshTokenCookieResolver.resolve(request);
@@ -71,8 +88,18 @@ public class AuthController {
                 "토큰 재발급에 성공했습니다." ));
     }
 
+    @Operation(
+            summary = "CSRF 토큰 발급",
+            description = "CSRF 보호가 필요한 요청에서 사용할 CSRF 토큰을 발급합니다.<br>" +
+                    "서버는 CSRF 토큰을 XSRF-TOKEN Cookie로 내려줍니다.<br>" +
+                    "이후 상태 변경 요청에서는 XSRF-TOKEN Cookie와 함께 X-XSRF-TOKEN Header가 전달되어야 합니다.(공격자가 임의로 넣기 어려운 커스텀 Header에도 같은 토큰이 들어왔는지 확인하는 작업을 함.)<br>" +
+                    "Axios 등 HTTP 클라이언트 설정에 따라 Cookie 값을 Header로 자동 반영할 수 있습니다."
+    )
     @GetMapping("/csrf")
-    public ResponseEntity<ApiResponse<CsrfTokenResponse>> csrf(CsrfToken csrfToken) {
+    public ResponseEntity<ApiResponse<CsrfTokenResponse>> csrf(
+            @Parameter(hidden = true)
+            CsrfToken csrfToken
+    ) {
         return ResponseEntity.ok(ApiResponse.success(
                 200,
                 new CsrfTokenResponse(csrfToken.getToken()),

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantAgreementRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantAgreementRequestDTO.java
@@ -1,23 +1,30 @@
 package com.weiver.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record ApplicantAgreementRequestDTO(
+        @Schema(description = "서비스 이용 약관 동의 여부", example = "true")
         @NotNull(message = "서비스 이용 약관 동의 여부는 필수입니다.")
         Boolean termsOfService,
 
+        @Schema(description = "개인정보 처리방침 동의 여부", example = "true")
         @NotNull(message = "개인정보 처리방침 동의 여부는 필수입니다.")
         Boolean privacyPolicy,
 
+        @Schema(description = "개인회원 이용약관 동의 여부", example = "true")
         @NotNull(message = "개인회원 이용약관 동의 여부는 필수입니다.")
         Boolean individualMemberTerms,
 
+        @Schema(description = "AI 분석 서비스 이용 동의 여부", example = "true")
         @NotNull(message = "AI 분석 서비스 이용동의 여부는 필수입니다.")
         Boolean aiAnalysisConsent,
 
+        @Schema(description = "민감정보 및 영상/음성 데이터 이용 동의 여부", example = "true")
         @NotNull(message = "민감정보 및 영상/음성 데이터 이용 동의 여부는 필수입니다.")
         Boolean sensitiveDataConsent,
 
+        @Schema(description = "마케팅 정보 수신 동의 여부", example = "false")
         @NotNull(message = "마케팅 정보 수신 동의 여부를 선택해주세요.")
         Boolean marketingConsent
 ) {

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantEmailSendRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantEmailSendRequestDTO.java
@@ -1,9 +1,11 @@
 package com.weiver.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record ApplicantEmailSendRequestDTO(
+        @Schema(description = "구직자 이메일", example = "applicnat@example.com")
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantEmailVerifyRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantEmailVerifyRequestDTO.java
@@ -1,14 +1,17 @@
 package com.weiver.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record ApplicantEmailVerifyRequestDTO(
+        @Schema(description = "구직자 이메일", example = "applicnat@example.com")
         @NotBlank(message = "이메일은 필수 입력값입니다.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
         String email,
 
+        @Schema(description = "인증번호", example = "131412")
         @NotBlank(message = "인증번호는 필수 입력값입니다.")
         @Pattern(regexp = "\\d{6}", message = "인증번호는 6자리 숫자여야 합니다.")
         String code

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantLoginRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantLoginRequestDTO.java
@@ -1,13 +1,16 @@
 package com.weiver.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record ApplicantLoginRequestDTO(
+        @Schema(description = "구직자 이메일", example = "applicant@example.com")
         @NotBlank(message = "이메일은 필수 입력값입니다.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
         String email,
 
+        @Schema(description = "비밀번호", example = "Password123!")
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
         String password
 ) {

--- a/src/main/java/com/weiver/auth/dto/request/ApplicantSignupRequestDTO.java
+++ b/src/main/java/com/weiver/auth/dto/request/ApplicantSignupRequestDTO.java
@@ -1,13 +1,16 @@
 package com.weiver.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 
 public record ApplicantSignupRequestDTO(
+        @Schema(description = "구직자 이메일", example = "applicant@example.com")
         @NotBlank(message = "이메일은 필수 입력값입니다.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
         String email,
 
+        @Schema(description = "비밀번호", example = "Password123!")
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
         @Pattern(
                 regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}:;\"'<>,.?/]).{8,64}$",
@@ -15,12 +18,15 @@ public record ApplicantSignupRequestDTO(
         )
         String password,
 
+        @Schema(description = "비밀번호 확인값", example = "Password123!")
         @NotBlank(message = "비밀번호 확인은 필수 입력값입니다.")
         String passwordConfirm,
 
+        @Schema(description = "인증 토큰", example = "123e4567-e89b-12d3-a456-426614174000")
         @NotBlank(message = "이메일 인증 토큰은 필수 입력값입니다.")
         String verificationToken,
 
+        @Schema(description = "약관 동의 정보")
         @Valid
         @NotNull(message = "약관 동의 정보는 필수 입력값입니다.")
         ApplicantAgreementRequestDTO agreements

--- a/src/main/java/com/weiver/auth/dto/response/ApplicantEmailVerifyResponseDTO.java
+++ b/src/main/java/com/weiver/auth/dto/response/ApplicantEmailVerifyResponseDTO.java
@@ -1,6 +1,9 @@
 package com.weiver.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record ApplicantEmailVerifyResponseDTO(
+        @Schema(description = "인증토큰", example = "123e4567-e89b-12d3-a456-426614174000")
         String verificationToken
 ) {
 }

--- a/src/main/java/com/weiver/auth/dto/response/ApplicantLoginResponseDTO.java
+++ b/src/main/java/com/weiver/auth/dto/response/ApplicantLoginResponseDTO.java
@@ -1,9 +1,13 @@
 package com.weiver.auth.dto.response;
 
 import com.weiver.global.common.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ApplicantLoginResponseDTO(
+        @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiJ9...")
         String accessToken,
+
+        @Schema(description = "사용자 권한", example = "APPLICANT")
         UserRole role
 ) {
 }

--- a/src/main/java/com/weiver/auth/dto/response/CsrfTokenResponse.java
+++ b/src/main/java/com/weiver/auth/dto/response/CsrfTokenResponse.java
@@ -1,6 +1,9 @@
 package com.weiver.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record CsrfTokenResponse(
+        @Schema(description = "CSRF 토큰", example = "abc123")
         String csrfToken
 ) {
 }

--- a/src/main/java/com/weiver/auth/dto/response/ReissueResponseDTO.java
+++ b/src/main/java/com/weiver/auth/dto/response/ReissueResponseDTO.java
@@ -1,6 +1,9 @@
 package com.weiver.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record ReissueResponseDTO(
+        @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiJ9...")
         String accessToken
 ) {
 }

--- a/src/main/java/com/weiver/global/config/SwaggerConfig.java
+++ b/src/main/java/com/weiver/global/config/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package com.weiver.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "WEIVER API",
+                description = "WEIVER Server API Documentation",
+                version = "v1"
+        )
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
+)
+@Configuration
+public class SwaggerConfig {
+}


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
구직자 인증 API 및 공통 인증 API에 대한 SpringDoc OpenAPI(Swagger) 문서화 작업입니다.
SwaggerConfig를 추가하고, 각 컨트롤러 및 DTO에 OpenAPI 어노테이션을 적용했습니다.

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- `SwaggerConfig` 추가: OpenAPI 3.0 기본 정보 및 `bearerAuth` Security Scheme 설정
- Controller에 @Tag`, `@Operation`, `@SecurityRequirement` 어노테이션 적용
- Request/Response DTO 필드에 @Schema 어노테이션 적용 
- Swagger UI에 노출 불필요한 파라미터(HttpServletRequest, HttpServletResponse, CsrfToken, AuthenticatedPrincipal)에 @Parameter(hidden = true) 적용 

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
개발 도중 signup 관련 ResponseDTO가 publicId가 아닌 applicantId로 되어있어서 추후 수정할 예정입니다. 수정할 때에 문서화 작업까지 하겠습니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #30 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 