### PR TITLE
[FIX] 회원가입 응답 수정

### DIFF
--- a/src/main/java/com/weiver/auth/dto/response/ApplicantSignupResponseDTO.java
+++ b/src/main/java/com/weiver/auth/dto/response/ApplicantSignupResponseDTO.java
@@ -2,16 +2,18 @@ package com.weiver.auth.dto.response;
 
 import com.weiver.applicant.domain.Applicant;
 import com.weiver.global.common.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ApplicantSignupResponseDTO(
-        Long applicantId,
-        String email,
+        @Schema(description = "외부 노출용 식별자인 publicId", example = "550e8400-e29b...")
+        String publicId,
+
+        @Schema(description = "권한", example = "Applicant")
         UserRole role
 ) {
     public static ApplicantSignupResponseDTO from(Applicant applicant) {
         return new ApplicantSignupResponseDTO(
-                applicant.getApplicantId(),
-                applicant.getEmail(),
+                applicant.getPublicId(),
                 applicant.getRole()
         );
     }

--- a/src/test/java/com/weiver/domain/auth/controller/ApplicantAuthControllerTest.java
+++ b/src/test/java/com/weiver/domain/auth/controller/ApplicantAuthControllerTest.java
@@ -146,7 +146,7 @@ public class ApplicantAuthControllerTest {
                 "new@test.com", "Pass1234!", "Pass1234!", "verification-token", allTrueAgreements()
         );
         when(applicantAuthService.signup(any()))
-                .thenReturn(new ApplicantSignupResponseDTO(1L, "new@test.com", UserRole.APPLICANT));
+                .thenReturn(new ApplicantSignupResponseDTO("uuid-applicant-1", UserRole.APPLICANT));
 
         // when & then
         mockMvc.perform(post("/api/auth/applicants/signup")
@@ -154,8 +154,7 @@ public class ApplicantAuthControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk()) // ResponseEntity.ok()로 감쌈
                 .andExpect(jsonPath("$.code").value(201))
-                .andExpect(jsonPath("$.data.applicantId").value(1))
-                .andExpect(jsonPath("$.data.email").value("new@test.com"))
+                .andExpect(jsonPath("$.data.publicId").value("uuid-applicant-1"))
                 .andExpect(jsonPath("$.data.role").value("APPLICANT"))
                 .andExpect(jsonPath("$.message").value("회원가입에 성공했습니다."));
     }

--- a/src/test/java/com/weiver/domain/auth/service/ApplicantAuthServiceTest.java
+++ b/src/test/java/com/weiver/domain/auth/service/ApplicantAuthServiceTest.java
@@ -226,10 +226,12 @@ public class ApplicantAuthServiceTest {
                 .thenReturn(Optional.of(email));
         when(passwordEncoder.encode(password)).thenReturn("encoded");
 
+        String expectedPublicId = "test-public-id";
         Applicant saved = Applicant.builder()
                 .email(email)
                 .password("encoded")
                 .role(UserRole.APPLICANT)
+                .publicId(expectedPublicId)
                 .build();
         ReflectionTestUtils.setField(saved, "applicantId", 1L);
         when(applicantRepository.save(any(Applicant.class))).thenReturn(saved);
@@ -238,8 +240,7 @@ public class ApplicantAuthServiceTest {
         ApplicantSignupResponseDTO response = applicantAuthService.signup(request);
 
         // then
-        assertThat(response.applicantId()).isEqualTo(1L);
-        assertThat(response.email()).isEqualTo(email);
+        assertThat(response.publicId()).isEqualTo(expectedPublicId);
         assertThat(response.role()).isEqualTo(UserRole.APPLICANT);
 
         verify(emailVerificationRepository).findAndDeleteVerifiedToken(token);


### PR DESCRIPTION
## 📝 PR 설명   
회원가입 응답 DTO에서 내부 식별자(applicantId)와 이메일을 제거하고, 외부 노출용 publicId만 반환하도록 변경합니다.                                                                                                                                    
   
## 📝 Summary                                                                                                                                                                    
- `ApplicantSignupResponseDTO`: `applicantId`, `email` 필드 제거 → `publicId` 필드로 교체
- `ApplicantAuthControllerTest`: 변경된 DTO에 맞게 목 응답 및 jsonPath 검증 수정                                                                                                 
- `ApplicantAuthServiceTest`: `signup_success` 테스트의 응답 필드 검증 수정                                                                                           
                                                                                                                                                                                   
## 🙏 Question & PR point                                                                                                                                                        
- 내부 DB PK(`applicantId`)와 이메일을 API 응답에서 제거해 불필요한 정보 노출을 방지했습니다. 

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #44 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)