### PR TITLE
[FIX] CORS preflight 오류 해결

### DIFF
--- a/src/main/java/com/weiver/global/config/CorsConfig.java
+++ b/src/main/java/com/weiver/global/config/CorsConfig.java
@@ -3,6 +3,7 @@ package com.weiver.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.List;
 public class CorsConfig {
 
     @Bean
-    public UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
 
         corsConfiguration.setAllowedOrigins(List.of(

--- a/src/main/java/com/weiver/global/config/SecurityConfig.java
+++ b/src/main/java/com/weiver/global/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 import java.util.stream.Stream;
 
@@ -33,10 +34,11 @@ public class SecurityConfig {
     private final SecurityErrorResponseWriter securityErrorResponseWriter;
     private final CsrfCookieFilter csrfCookieFilter;
     private final CsrfCookieProperties csrfCookieProperties;
+    private final CorsConfigurationSource corsConfigurationSource;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.cors(cors -> {});
+        http.cors(cors -> cors.configurationSource(corsConfigurationSource));
         http.csrf(csrf -> csrf
                 .csrfTokenRepository(cookieCsrfTokenRepository())
                 .ignoringRequestMatchers(
@@ -64,6 +66,7 @@ public class SecurityConfig {
                 );
 
         http.authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(WhiteListConfig.swaggerWhitelist().toArray(String[]::new)).permitAll()
                         .requestMatchers(WhiteListConfig.serverWhitelist().toArray(String[]::new)).permitAll()
                         .requestMatchers(WhiteListConfig.authWhitelist().toArray(String[]::new)).permitAll()

--- a/src/test/java/com/weiver/global/config/SecurityCorsConfigTest.java
+++ b/src/test/java/com/weiver/global/config/SecurityCorsConfigTest.java
@@ -1,4 +1,4 @@
-인package com.weiver.global.config;
+package com.weiver.global.config;
 
 import com.weiver.auth.controller.ApplicantAuthController;
 import com.weiver.auth.service.ApplicantAuthService;

--- a/src/test/java/com/weiver/global/config/SecurityCorsConfigTest.java
+++ b/src/test/java/com/weiver/global/config/SecurityCorsConfigTest.java
@@ -1,0 +1,65 @@
+인package com.weiver.global.config;
+
+import com.weiver.auth.controller.ApplicantAuthController;
+import com.weiver.auth.service.ApplicantAuthService;
+import com.weiver.global.security.cookie.CookieProvider;
+import com.weiver.global.security.csrf.CsrfCookieFilter;
+import com.weiver.global.security.handler.SecurityErrorResponseWriter;
+import com.weiver.global.security.jwt.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApplicantAuthController.class)
+@AutoConfigureMockMvc
+@Import({
+        CorsConfig.class,
+        SecurityConfig.class,
+        CsrfCookieFilter.class,
+        SecurityErrorResponseWriter.class
+})
+@TestPropertySource(properties = {
+        "cookie.csrf-token.cookie-name=XSRF-TOKEN",
+        "cookie.csrf-token.header-name=X-XSRF-TOKEN",
+        "cookie.csrf-token.path=/",
+        "cookie.csrf-token.domain=",
+        "cookie.csrf-token.secure=false",
+        "cookie.csrf-token.same-site=Lax"
+})
+class SecurityCorsConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ApplicantAuthService applicantAuthService;
+
+    @MockitoBean
+    private CookieProvider cookieProvider;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    @DisplayName("localhost:3000에서 보내는 이메일 인증 preflight 요청을 허용한다")
+    void allowApplicantEmailSendPreflightFromLocalhost() throws Exception {
+        mockMvc.perform(options("/api/auth/applicants/email/send")
+                        .header(HttpHeaders.ORIGIN, "http://localhost:3000")
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST")
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, "content-type"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:3000"))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명

로컬 프론트엔드에서 운영 API를 호출할 때 발생하던 CORS preflight `403 Invalid CORS request` 문제를 수정했습니다.

## 📝 Summary

- `CorsConfig`의 CORS 설정 Bean을 `CorsConfigurationSource`로 명확히 노출
- `SecurityConfig`에서 `CorsConfigurationSource`를 명시적으로 사용하도록 설정
- `OPTIONS /**` 요청을 `permitAll` 처리하여 preflight 요청이 인증/인가 단계에서 막히지 않도록 개선
- `http://localhost:3000`에서 보내는 이메일 인증 API preflight 요청 검증 테스트 추가

## 🙏 Question & PR point

## 📬 Postman

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #65 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured cross-origin request configuration for improved flexibility.

* **Tests**
  * Added validation tests for cross-origin preflight request handling and credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-WEIVER/WEIVER-SERVER/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->