### PR TITLE
[FIX] CORS 허용 목록에 주소 추가 및 CSRF domain 설정 오류 해결

### DIFF
--- a/src/main/java/com/weiver/global/config/CorsConfig.java
+++ b/src/main/java/com/weiver/global/config/CorsConfig.java
@@ -17,6 +17,7 @@ public class CorsConfig {
 
         corsConfiguration.setAllowedOrigins(List.of(
                 "https://www.piuda.site",
+                "https://weiver.local.piuda.site:3000",
                 "http://localhost:3000"
         ));
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -121,7 +121,7 @@ cookie:
     cookie-name: XSRF-TOKEN
     header-name: X-XSRF-TOKEN
     path: /
-    domain: .piuda.site
+    domain: piuda.site
     secure: true
     same-site: None
 


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
프론트엔드 개발자가 요청한 주소를 CORS 허용 목록에 추가했습니다.
Tomcat이 RFC6265 기준으로 쿠키 도메인을 검증하는데 CSRF domain설정에 온점이 들어가게 되면 invalid domain 으로 판단해서 오류가 발생하는 문제를 해결했습니다.


## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- CORS 허용 origin 목록에 필요한 프론트엔드 주소 추가
- `application.yaml`의 CSRF 토큰 쿠키 domain 설정에서 앞쪽 온점(`.`) 제거


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #68 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated cross-origin resource sharing (CORS) configuration to support an additional origin
  * Updated CSRF token domain configuration in production environment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-WEIVER/WEIVER-SERVER/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->