### PR TITLE
[Fix] CI/CD 환경 빌드 태스크 충돌 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,9 +201,6 @@ tasks.withType(Test).configureEach {
     }
 }
 
-tasks.named('generateSentryBundleIdJava') {
-    mustRunAfter tasks.named('compileJava')
-}
 
 bootJar {
     archiveFileName = 'app.jar'
@@ -222,4 +219,20 @@ sentry {
     org = "weiver"
     projectName = "java-spring-boot"
     authToken = System.getenv("SENTRY_AUTH_TOKEN")
+}
+
+afterEvaluate {
+    def sentryTasks = [
+            'generateSentryBundleIdJava',
+            'sentryCollectSourcesJava',
+            'uploadSentrySourceContextJava'
+    ]
+
+    sentryTasks.each { taskName ->
+        if (tasks.findByName(taskName)) {
+            tasks.named(taskName) {
+                mustRunAfter tasks.named('compileJava')
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
본 PR은 CI/CD 환경(GitHub Actions)에서 발생하는 Sentry 플러그인과 QueryDSL 간의 빌드 태스크 충돌(순서 꼬임) 에러를 해결하는 작업입니다.


## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- Sentry Gradle Task 실행 순서 보장 (build.gradle 수정)
    Sentry가 소스코드를 수집하고 업로드하는 태스크(sentryCollectSourcesJava 등)가 QueryDSL Q클래스 생성 폴더를 참조할 때 발생하는 암묵적 의존성(Implicit Dependency) 에러 해결.

    afterEvaluate 블록을 추가하여, compileJava 태스크가 완전히 끝난 후에만 Sentry 관련 주요 태스크들이 실행되도록 mustRunAfter로 명시적 순서 강제 부여.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
로컬에서는 간헐적으로 성공하더라도, GitHub Actions 같은 멀티 코어 환경에서는 빌드 순서가 보장되지 않아 발생했던 고질적인 문제입니다. 이번 패치로 CI/CD 파이프라인이 안정적으로 구동됩니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #83 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration to streamline task sequencing and improve build system maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->