### PR TITLE
[FEATURE] Spring 이벤트 Publisher/Consumer 구조 구현

### DIFF
--- a/src/main/java/com/weiver/global/event/consumer/DomainEventDispatcher.java
+++ b/src/main/java/com/weiver/global/event/consumer/DomainEventDispatcher.java
@@ -18,7 +18,17 @@ public class DomainEventDispatcher {
     public DomainEventDispatcher(List<DomainEventHandler> handlerList) {
         this.handlers = new EnumMap<>(EventType.class);
         for(DomainEventHandler handler : handlerList) {
-            this.handlers.put(handler.support(), handler);
+            DomainEventHandler previous = this.handlers.putIfAbsent(handler.support(), handler);
+            if (previous != null) {
+                throw new IllegalStateException(
+                        "Duplicate domain event handler registration. eventType="
+                                + handler.support()
+                                + ", existingHandler="
+                                + previous.getClass().getName()
+                                + ", duplicateHandler="
+                                + handler.getClass().getName()
+                );
+            }
         }
     }
 

--- a/src/main/java/com/weiver/global/event/consumer/DomainEventDispatcher.java
+++ b/src/main/java/com/weiver/global/event/consumer/DomainEventDispatcher.java
@@ -1,0 +1,33 @@
+package com.weiver.global.event.consumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.UnsupportedEventTypeException;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class DomainEventDispatcher {
+
+    private final Map<EventType, DomainEventHandler> handlers;
+
+    public DomainEventDispatcher(List<DomainEventHandler> handlerList) {
+        this.handlers = new EnumMap<>(EventType.class);
+        for(DomainEventHandler handler : handlerList) {
+            this.handlers.put(handler.support(), handler);
+        }
+    }
+
+    public void dispatch(EventEnvelope<JsonNode> envelope) {
+        DomainEventHandler handler = handlers.get(envelope.eventType());
+        if(handler == null) {
+            throw new UnsupportedEventTypeException(envelope.eventType());
+        }
+
+        handler.handle(envelope);
+    }
+}

--- a/src/main/java/com/weiver/global/event/consumer/DomainEventHandler.java
+++ b/src/main/java/com/weiver/global/event/consumer/DomainEventHandler.java
@@ -1,0 +1,12 @@
+package com.weiver.global.event.consumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+
+public interface DomainEventHandler {
+
+    EventType support();
+
+    void handle(EventEnvelope<JsonNode> envelope);
+}

--- a/src/main/java/com/weiver/global/event/consumer/DomainEventListener.java
+++ b/src/main/java/com/weiver/global/event/consumer/DomainEventListener.java
@@ -1,0 +1,53 @@
+package com.weiver.global.event.consumer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.Channel;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.exception.RetryableEventException;
+import com.weiver.global.event.validation.EventEnvelopeValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DomainEventListener {
+
+    private final ObjectMapper objectMapper;
+    private final EventEnvelopeValidator validator;
+    private final DomainEventDispatcher dispatcher;
+
+    @RabbitListener(queues = "${weiver.rabbitmq.spring-queue}")
+    public void onMessage(Message message, Channel channel) throws IOException {
+        long deliveryTag = message.getMessageProperties().getDeliveryTag();
+
+        try {
+            EventEnvelope<JsonNode> envelope = objectMapper.readValue(message.getBody(), new TypeReference<>() {});
+
+            validator.validate(envelope);
+
+            log.info(
+                    "RabbitMQ event received. eventId={}, eventType={}, correlationId={}",
+                    envelope.eventId(),
+                    envelope.eventType(),
+                    envelope.correlationId()
+            );
+
+            dispatcher.dispatch(envelope);
+            channel.basicAck(deliveryTag, false);
+        } catch (RetryableEventException e) {
+            log.warn("Retryable event handling failed. Move to DLQ. reason={}", e.getMessage());
+            channel.basicNack(deliveryTag, false, false);
+        } catch (Exception e) {
+            log.error("Event handling failed. Move to DLQ.", e);
+            channel.basicNack(deliveryTag, false, false);
+        }
+    }
+}

--- a/src/main/java/com/weiver/global/event/exception/EventHandlingException.java
+++ b/src/main/java/com/weiver/global/event/exception/EventHandlingException.java
@@ -1,0 +1,11 @@
+package com.weiver.global.event.exception;
+
+public abstract class EventHandlingException extends RuntimeException {
+    protected EventHandlingException(String message) {
+        super(message);
+    }
+
+    protected EventHandlingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/weiver/global/event/exception/NonRetryableEventException.java
+++ b/src/main/java/com/weiver/global/event/exception/NonRetryableEventException.java
@@ -1,0 +1,11 @@
+package com.weiver.global.event.exception;
+
+public class NonRetryableEventException extends EventHandlingException{
+    public NonRetryableEventException(String message) {
+        super(message);
+    }
+
+    public NonRetryableEventException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/weiver/global/event/exception/RetryableEventException.java
+++ b/src/main/java/com/weiver/global/event/exception/RetryableEventException.java
@@ -1,0 +1,11 @@
+package com.weiver.global.event.exception;
+
+public class RetryableEventException extends EventHandlingException {
+    public RetryableEventException(String message) {
+        super(message);
+    }
+
+    public RetryableEventException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/weiver/global/event/exception/UnsupportedEventTypeException.java
+++ b/src/main/java/com/weiver/global/event/exception/UnsupportedEventTypeException.java
@@ -1,0 +1,9 @@
+package com.weiver.global.event.exception;
+
+import com.weiver.global.event.dto.EventType;
+
+public class UnsupportedEventTypeException extends NonRetryableEventException {
+    public UnsupportedEventTypeException(EventType eventType) {
+        super("Unsupported event type: " + eventType);
+    }
+}

--- a/src/main/java/com/weiver/global/event/exception/UnsupportedEventVersionException.java
+++ b/src/main/java/com/weiver/global/event/exception/UnsupportedEventVersionException.java
@@ -1,0 +1,7 @@
+package com.weiver.global.event.exception;
+
+public class UnsupportedEventVersionException extends NonRetryableEventException {
+    public UnsupportedEventVersionException(String version) {
+        super("Unsupported event version: " + version);
+    }
+}

--- a/src/main/java/com/weiver/global/event/publisher/DomainEventPublisher.java
+++ b/src/main/java/com/weiver/global/event/publisher/DomainEventPublisher.java
@@ -1,0 +1,60 @@
+package com.weiver.global.event.publisher;
+
+import com.weiver.global.event.config.RabbitMqProperties;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.util.EventRoutingKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DomainEventPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final RabbitMqProperties properties;
+
+    public void publish(EventEnvelope<?> envelope) {
+        String routingKey = EventRoutingKeys.from(envelope.eventType());
+        CorrelationData correlationData = new CorrelationData(envelope.eventId());
+
+        rabbitTemplate.convertAndSend(
+                properties.domainExchange(),
+                routingKey,
+                envelope,
+                correlationData
+        );
+
+        correlationData.getFuture().whenComplete((confirm, ex) -> {
+            if (ex != null) {
+                log.error("RabbitMQ publish confirm failed. eventId={}, eventType={}, routingKey={}",
+                        envelope.eventId(),
+                        envelope.eventType(),
+                        routingKey
+                );
+                return;
+            }
+            if (confirm == null || !confirm.isAck()) {
+                log.error(
+                        "RabbitMQ publish not acknowledged. eventId={}, eventType={}, routingKey={}, reason={}",
+                        envelope.eventId(),
+                        envelope.eventType(),
+                        routingKey,
+                        confirm != null ? confirm.getReason() : null
+                );
+                return;
+            }
+
+            log.info(
+                    "RabbitMQ event published. eventId={}, eventType={}, correlationId={}, routingKey={}",
+                    envelope.eventId(),
+                    envelope.eventType(),
+                    envelope.correlationId(),
+                    routingKey
+            );
+        });
+    }
+}

--- a/src/main/java/com/weiver/global/event/publisher/DomainEventPublisher.java
+++ b/src/main/java/com/weiver/global/event/publisher/DomainEventPublisher.java
@@ -8,16 +8,23 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class DomainEventPublisher {
 
+    private static final long PUBLISH_CONFIRM_TIMEOUT_SECONDS = 10L;
+
     private final RabbitTemplate rabbitTemplate;
     private final RabbitMqProperties properties;
 
     public void publish(EventEnvelope<?> envelope) {
+        validateEnvelope(envelope);
+
         String routingKey = EventRoutingKeys.from(envelope.eventType());
         CorrelationData correlationData = new CorrelationData(envelope.eventId());
 
@@ -28,12 +35,13 @@ public class DomainEventPublisher {
                 correlationData
         );
 
-        correlationData.getFuture().whenComplete((confirm, ex) -> {
+        correlationData.getFuture().orTimeout(PUBLISH_CONFIRM_TIMEOUT_SECONDS, TimeUnit.SECONDS).whenComplete((confirm, ex) -> {
             if (ex != null) {
                 log.error("RabbitMQ publish confirm failed. eventId={}, eventType={}, routingKey={}",
                         envelope.eventId(),
                         envelope.eventType(),
-                        routingKey
+                        routingKey,
+                        ex
                 );
                 return;
             }
@@ -56,5 +64,17 @@ public class DomainEventPublisher {
                     routingKey
             );
         });
+    }
+
+    private void validateEnvelope(EventEnvelope<?> envelope) {
+        if (envelope == null) {
+            throw new IllegalArgumentException("Event envelope must not be null");
+        }
+        if (!StringUtils.hasText(envelope.eventId())) {
+            throw new IllegalArgumentException("event_id is required for publishing");
+        }
+        if (envelope.eventType() == null) {
+            throw new IllegalArgumentException("event_type is required for publishing");
+        }
     }
 }

--- a/src/main/java/com/weiver/global/event/validation/EventEnvelopeValidator.java
+++ b/src/main/java/com/weiver/global/event/validation/EventEnvelopeValidator.java
@@ -1,0 +1,35 @@
+package com.weiver.global.event.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.exception.NonRetryableEventException;
+import com.weiver.global.event.exception.UnsupportedEventVersionException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class EventEnvelopeValidator {
+
+    private static final String SUPPORTED_VERSION = "1.0";
+
+    public void validate(EventEnvelope<JsonNode> envelope) {
+        if(envelope == null) {
+            throw new NonRetryableEventException("Event envelope is null");
+        }
+        if (!StringUtils.hasText(envelope.eventId())) {
+            throw new NonRetryableEventException("event_id is required");
+        }
+        if (envelope.eventType() == null) {
+            throw new NonRetryableEventException("event_type is required");
+        }
+        if (!SUPPORTED_VERSION.equals(envelope.version())) {
+            throw new UnsupportedEventVersionException(envelope.version());
+        }
+        if (envelope.occurredAt() == null) {
+            throw new NonRetryableEventException("occurred_at is required");
+        }
+        if (envelope.data() == null || envelope.data().isNull()) {
+            throw new NonRetryableEventException("data is required");
+        }
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
RabbitMQ 기반 Spring-AI 비동기 이벤트 연동을 위한 공통 Publisher/Consumer 구조를 구현했습니다.
이번 PR은 실제 도메인 이벤트 처리 로직을 붙이기 전 단계로, Spring에서 이벤트를 발행하고 AI 서버가 발행한 결과 이벤트를 수신해 event type별 handler로 위임할 수 있는 기반을 추가합니다.

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- RabbitMQ 이벤트 발행을 담당하는 `DomainEventPublisher`를 추가했습니다.
- event type을 routing key로 자동 변환해 `domain.events` exchange에 발행하도록 구현했습니다.
- publisher confirm 결과를 `CorrelationData(event_id)` 기준으로 추적하도록 구현했습니다.
- Spring 결과 이벤트 수신용 `DomainEventListener`를 추가했습니다.
- `EventEnvelope<JsonNode>` 기반으로 메시지를 파싱하고 validator를 거쳐 dispatcher에 위임하도록 구성했습니다.
- `DomainEventDispatcher`, `DomainEventHandler`를 추가해 event type별 handler 분기 구조를 만들었습니다.
- retry 가능/불가능 이벤트 예외와 미지원 event type/version 예외를 추가했습니다.
- envelope 필수 필드와 version을 검증하는 `EventEnvelopeValidator`를 추가했습니다.
- 처리 성공 시 `basicAck`, 실패 시 `basicNack(requeue=false)`로 DLQ 이동하도록 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 현재 PR은 공통 Publisher/Consumer 구조까지만 포함합니다. `JD_ANALYSIS_COMPLETED`, `MATCHING_COMPLETED` 등 실제 도메인 handler 구현은 다음 이슈에서 진행할 예정입니다.
- 아직 등록된 도메인 handler가 없는 event type을 수신하면 `UnsupportedEventTypeException`이 발생하고 DLQ로 이동합니다.
- `NonRetryableEventException`은 validator에서 사용되며, 현재 listener에서는 최종 `Exception` catch에서 잡아 DLQ로 보냅니다.
- RabbitMQ listener는 manual ack 방식이므로 DB 저장 또는 중복 확인 완료 후 ack하는 정책을 이후 handler 구현에서도 유지해야 합니다.
- payload 전체 로그는 남기지 않고 `event_id`, `event_type`, `correlation_id` 중심으로만 추적합니다.
- PENDING/FAILED 상태 영속화는 맞는 방향이지만, 이번 PR은 공통 Publisher/Consumer 인프라 범위라 global publisher에서 임의의 publish-status 저장소를 추가하지 않았습니다. 각 도메인별 상태 컬럼(JD 분석 상태, 프로필 동기화 상태, 면접 세션 상태)은 후속 DB 멱등성/도메인 플로우 이슈에서 추가하고, 발행 호출부에서 PENDING/REQUESTED/FAILED를 관리하도록 구현하겠습니다.


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #74 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event consumption and processing capabilities from message queue with automatic error handling and retry logic
  * Added event publishing to message queue with delivery confirmation and detailed logging
  * Implemented event validation to ensure data integrity during processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->