### PR TITLE
[FEATURE] 작성 여부 확인 API 개선

### DIFF
--- a/src/main/java/com/weiver/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/weiver/applicant/controller/ApplicantController.java
@@ -5,6 +5,7 @@ import com.weiver.applicant.dto.request.post.CertificateRequestDTO;
 import com.weiver.applicant.dto.request.post.EducationRequestDTO;
 import com.weiver.applicant.dto.request.post.WorkExperienceRequestDTO;
 import com.weiver.applicant.dto.request.put.*;
+import com.weiver.applicant.dto.response.ApplicantDocumentStatusResponseDTO;
 import com.weiver.applicant.dto.response.ApplicantInfoResponseDTO;
 import com.weiver.applicant.service.*;
 import com.weiver.global.common.ApiResponse;
@@ -54,6 +55,20 @@ public class ApplicantController {
 
         return ResponseEntity.ok(ApiResponse.success(responseDTO));
 
+    }
+
+    @Operation(
+            summary = "지원자 필수 제출 서류 작성 상태 조회",
+            description = "AI 면접 진행 전 필요한 이력서, 자기소개서, 포트폴리오 작성 완료 여부를 boolean 값으로 반환합니다."
+    )
+    @GetMapping("/document-status")
+    public ResponseEntity<ApiResponse<ApplicantDocumentStatusResponseDTO>> getDocumentStatus(
+            @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
+        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
+
+        ApplicantDocumentStatusResponseDTO responseDTO = applicantService.getDocumentStatus(principal.publicId());
+
+        return ResponseEntity.ok(ApiResponse.success(responseDTO));
     }
 
     @Operation(

--- a/src/main/java/com/weiver/applicant/dto/response/ApplicantDetailResponseDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/response/ApplicantDetailResponseDTO.java
@@ -12,7 +12,7 @@ public record ApplicantDetailResponseDTO(
         @Schema(description = "지원자 실명", example = "이현우")
         String name,
 
-        @Schema(description = "생년월일 (YYYY-MM-DD 형식)", example = "2000-01-01")
+        @Schema(description = "생년월일 (YYYY-MM-DD 형식)", example = "2000-01-01", nullable = true)
         String birthday,
 
         @Schema(description = "휴대폰 번호 (하이픈 포함)", example = "010-1234-5678")
@@ -25,7 +25,7 @@ public record ApplicantDetailResponseDTO(
         return new ApplicantDetailResponseDTO(
                 applicant.getPhotoUrl(),
                 applicant.getName(),
-                applicant.getBirthday().toString(),
+                applicant.getBirthday() != null ? applicant.getBirthday().toString() : null,
                 applicant.getPhoneNumber(),
                 applicant.getEmail()
         );

--- a/src/main/java/com/weiver/applicant/dto/response/ApplicantDocumentStatusResponseDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/response/ApplicantDocumentStatusResponseDTO.java
@@ -1,0 +1,17 @@
+package com.weiver.applicant.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "지원자 필수 제출 서류 작성 상태 응답 DTO")
+public record ApplicantDocumentStatusResponseDTO(
+
+        @Schema(description = "이력서 작성 완료 여부", example = "true")
+        boolean resumeCompleted,
+
+        @Schema(description = "자기소개서 작성 완료 여부", example = "true")
+        boolean essayCompleted,
+
+        @Schema(description = "포트폴리오 작성 완료 여부", example = "true")
+        boolean portfolioCompleted
+) {
+}

--- a/src/main/java/com/weiver/applicant/repository/AwardRepository.java
+++ b/src/main/java/com/weiver/applicant/repository/AwardRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface AwardRepository extends JpaRepository<Award, Long> {
     List<Award> findAllByApplicant(Applicant applicant);
+    boolean existsByApplicant(Applicant applicant);
 }

--- a/src/main/java/com/weiver/applicant/repository/CertificateRepository.java
+++ b/src/main/java/com/weiver/applicant/repository/CertificateRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface CertificateRepository extends JpaRepository<Certificate, Long> {
     List<Certificate> findAllByApplicant(Applicant applicant);
+    boolean existsByApplicant(Applicant applicant);
 }

--- a/src/main/java/com/weiver/applicant/repository/EducationRepository.java
+++ b/src/main/java/com/weiver/applicant/repository/EducationRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface EducationRepository extends JpaRepository<Education, Long>{
     List<Education> findAllByApplicant(Applicant applicant);
+    boolean existsByApplicant(Applicant applicant);
 }

--- a/src/main/java/com/weiver/applicant/repository/WorkExperienceRepository.java
+++ b/src/main/java/com/weiver/applicant/repository/WorkExperienceRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface WorkExperienceRepository extends JpaRepository<WorkExperience, Long> {
     List<WorkExperience> findAllByApplicantOrderByStartDateDesc(Applicant applicant);
+    boolean existsByApplicant(Applicant applicant);
 }

--- a/src/main/java/com/weiver/applicant/service/ApplicantService.java
+++ b/src/main/java/com/weiver/applicant/service/ApplicantService.java
@@ -4,11 +4,13 @@ import com.weiver.applicant.domain.*;
 import com.weiver.applicant.dto.request.put.*;
 import com.weiver.applicant.dto.response.*;
 import com.weiver.applicant.repository.*;
+import com.weiver.essay.repository.EssayAnswerRepository;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import com.weiver.global.s3.service.S3Service;
 import com.weiver.matching.dto.response.PortfolioDetailDTO;
 import com.weiver.matching.dto.response.ProfileDetailDTO;
+import com.weiver.portfolio.repository.PortfolioRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +30,8 @@ public class ApplicantService {
     private final AwardRepository awardRepository;
     private final CertificateRepository certificateRepository;
     private final WorkExperienceRepository workExperienceRepository;
+    private final EssayAnswerRepository essayAnswerRepository;
+    private final PortfolioRepository portfolioRepository;
     private final WorkExperienceService workExperienceService;
     private final S3Service s3Service;
 
@@ -85,6 +89,21 @@ public class ApplicantService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public ApplicantDocumentStatusResponseDTO getDocumentStatus(String publicId) {
+        Applicant applicant = getApplicant(publicId);
+
+        boolean resumeCompleted = isResumeCompleted(applicant);
+        boolean essayCompleted = essayAnswerRepository.existsByApplicant(applicant);
+        boolean portfolioCompleted = portfolioRepository.existsByApplicant(applicant);
+
+        return new ApplicantDocumentStatusResponseDTO(
+                resumeCompleted,
+                essayCompleted,
+                portfolioCompleted
+        );
+    }
+
     /**
      * 지원자 리포트 카드 조회 - 순수 도메인 데이터만 반환
      * */
@@ -98,5 +117,19 @@ public class ApplicantService {
         Applicant applicant = applicantRepository.findByPublicId(publicId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
         return applicant;
+    }
+
+    private boolean isResumeCompleted(Applicant applicant) {
+        boolean basicInfoCompleted = StringUtils.hasText(applicant.getName())
+                && StringUtils.hasText(applicant.getEmail())
+                && StringUtils.hasText(applicant.getPhoneNumber())
+                && applicant.getBirthday() != null;
+
+        boolean resumeDetailCompleted = educationRepository.existsByApplicant(applicant)
+                || workExperienceRepository.existsByApplicant(applicant)
+                || certificateRepository.existsByApplicant(applicant)
+                || awardRepository.existsByApplicant(applicant);
+
+        return basicInfoCompleted && resumeDetailCompleted;
     }
 }

--- a/src/main/java/com/weiver/essay/repository/EssayAnswerRepository.java
+++ b/src/main/java/com/weiver/essay/repository/EssayAnswerRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long> {
     Optional<EssayAnswer> findByApplicant(Applicant applicant);
+    boolean existsByApplicant(Applicant applicant);
 }

--- a/src/main/java/com/weiver/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/com/weiver/portfolio/repository/PortfolioRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     Optional<Portfolio> findByApplicant(Applicant applicant);
+    boolean existsByApplicant(Applicant applicant);
 }

--- a/src/test/java/com/weiver/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/weiver/applicant/controller/ApplicantControllerTest.java
@@ -180,6 +180,58 @@ class ApplicantControllerTest {
     }
 
     @Test
+    @DisplayName("지원자 필수 제출 서류 작성 상태 조회 성공")
+    void getDocumentStatus_Success() throws Exception {
+        // given
+        String publicId = "2222";
+        ApplicantDocumentStatusResponseDTO responseDTO = new ApplicantDocumentStatusResponseDTO(
+                true,
+                false,
+                true
+        );
+
+        given(applicantService.getDocumentStatus(publicId)).willReturn(responseDTO);
+
+        // when, then
+        mockMvc.perform(get("/api/applicants/document-status")
+                        .with(customAuth(publicId))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.resumeCompleted").value(true))
+                .andExpect(jsonPath("$.data.essayCompleted").value(false))
+                .andExpect(jsonPath("$.data.portfolioCompleted").value(true));
+    }
+
+    @Test
+    @DisplayName("엣지 케이스 : 필수 제출 서류 작성 상태 조회 시 Principal이 없으면 UNAUTHORIZED 에러 발생")
+    void getDocumentStatus_WithoutPrincipal_ThrowsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/applicants/document-status")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("엣지 케이스 : 필수 제출 서류 작성 상태 조회 시 지원자가 없으면 404 에러 발생")
+    void getDocumentStatus_ApplicantNotFound_ThrowsNotFound() throws Exception {
+        // given
+        String publicId = "not-found";
+
+        given(applicantService.getDocumentStatus(publicId))
+                .willThrow(new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        // when, then
+        mockMvc.perform(get("/api/applicants/document-status")
+                        .with(customAuth(publicId))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("APPLICANT_NOT_FOUND"));
+    }
+
+    @Test
     @DisplayName("엣지 케이스 : 남의 수상 이력 ID 조작 시도 -> 404 (또는 400) 에러 발생")
     void updateAwardInfo_WithOthersAwardId_ThrowsException() throws Exception {
         // given

--- a/src/test/java/com/weiver/applicant/service/ApplicantServiceImplTest.java
+++ b/src/test/java/com/weiver/applicant/service/ApplicantServiceImplTest.java
@@ -6,14 +6,17 @@ import com.weiver.applicant.dto.request.post.AwardRequestDTO;
 import com.weiver.applicant.dto.request.post.EducationDetailDTO;
 import com.weiver.applicant.dto.request.post.EducationRequestDTO;
 import com.weiver.applicant.dto.request.put.ApplicantInfoRequestDTO;
+import com.weiver.applicant.dto.response.ApplicantDocumentStatusResponseDTO;
 import com.weiver.applicant.dto.response.ApplicantInfoResponseDTO;
 import com.weiver.applicant.repository.*;
+import com.weiver.essay.repository.EssayAnswerRepository;
 import com.weiver.applicant.type.Degree;
 import com.weiver.applicant.type.EmploymentType;
 import com.weiver.applicant.type.Status;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import com.weiver.global.s3.service.S3Service;
+import com.weiver.portfolio.repository.PortfolioRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +47,8 @@ class ApplicantServiceImplTest {
     @Mock private AwardRepository awardRepository;
     @Mock private CertificateRepository certificateRepository;
     @Mock private WorkExperienceRepository workExperienceRepository;
+    @Mock private EssayAnswerRepository essayAnswerRepository;
+    @Mock private PortfolioRepository portfolioRepository;
     @Mock private S3Service s3Service;
 
     @InjectMocks
@@ -356,5 +361,104 @@ class ApplicantServiceImplTest {
         assertThat(responseDTO.award()).hasSize(1);
         assertThat(responseDTO.workExperience()).hasSize(1);
         assertThat(responseDTO.certificate()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("필수 제출 서류 상태 조회 시 이력서, 자기소개서, 포트폴리오가 모두 작성된 경우 모두 true를 반환한다.")
+    void getDocumentStatus_AllDocumentsCompleted_ReturnsAllTrue() {
+        // Given
+        String publicId = "2222";
+        Applicant applicant = completedBasicInfoApplicant(publicId);
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(educationRepository.existsByApplicant(applicant)).willReturn(true);
+        given(essayAnswerRepository.existsByApplicant(applicant)).willReturn(true);
+        given(portfolioRepository.existsByApplicant(applicant)).willReturn(true);
+
+        // When
+        ApplicantDocumentStatusResponseDTO responseDTO = applicantService.getDocumentStatus(publicId);
+
+        // Then
+        assertThat(responseDTO.resumeCompleted()).isTrue();
+        assertThat(responseDTO.essayCompleted()).isTrue();
+        assertThat(responseDTO.portfolioCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("필수 제출 서류 상태 조회 시 기본 정보는 있지만 이력서 상세 항목이 없으면 이력서는 false를 반환한다.")
+    void getDocumentStatus_NoResumeDetail_ReturnsResumeFalse() {
+        // Given
+        String publicId = "2222";
+        Applicant applicant = completedBasicInfoApplicant(publicId);
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(educationRepository.existsByApplicant(applicant)).willReturn(false);
+        given(workExperienceRepository.existsByApplicant(applicant)).willReturn(false);
+        given(certificateRepository.existsByApplicant(applicant)).willReturn(false);
+        given(awardRepository.existsByApplicant(applicant)).willReturn(false);
+        given(essayAnswerRepository.existsByApplicant(applicant)).willReturn(true);
+        given(portfolioRepository.existsByApplicant(applicant)).willReturn(true);
+
+        // When
+        ApplicantDocumentStatusResponseDTO responseDTO = applicantService.getDocumentStatus(publicId);
+
+        // Then
+        assertThat(responseDTO.resumeCompleted()).isFalse();
+        assertThat(responseDTO.essayCompleted()).isTrue();
+        assertThat(responseDTO.portfolioCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("필수 제출 서류 상태 조회 시 기본 필수 정보가 누락되면 이력서 상세 항목이 있어도 이력서는 false를 반환한다.")
+    void getDocumentStatus_MissingBasicInfo_ReturnsResumeFalse() {
+        // Given
+        String publicId = "2222";
+        Applicant applicant = Applicant.builder()
+                .publicId(publicId)
+                .name("이현우")
+                .email("test@example.com")
+                .phoneNumber("")
+                .birthday(LocalDate.of(2000, 1, 1))
+                .build();
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(educationRepository.existsByApplicant(applicant)).willReturn(true);
+        given(essayAnswerRepository.existsByApplicant(applicant)).willReturn(false);
+        given(portfolioRepository.existsByApplicant(applicant)).willReturn(true);
+
+        // When
+        ApplicantDocumentStatusResponseDTO responseDTO = applicantService.getDocumentStatus(publicId);
+
+        // Then
+        assertThat(responseDTO.resumeCompleted()).isFalse();
+        assertThat(responseDTO.essayCompleted()).isFalse();
+        assertThat(responseDTO.portfolioCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("필수 제출 서류 상태 조회 시 지원자가 존재하지 않으면 APPLICANT_NOT_FOUND 예외가 발생하고 서류 조회는 수행하지 않는다.")
+    void getDocumentStatus_ApplicantNotFound_ThrowsException() {
+        // Given
+        String publicId = "not-found";
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> applicantService.getDocumentStatus(publicId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.APPLICANT_NOT_FOUND);
+
+        verifyNoInteractions(educationRepository, workExperienceRepository, certificateRepository,
+                awardRepository, essayAnswerRepository, portfolioRepository);
+    }
+
+    private Applicant completedBasicInfoApplicant(String publicId) {
+        return Applicant.builder()
+                .publicId(publicId)
+                .name("이현우")
+                .email("test@example.com")
+                .phoneNumber("010-1234-5678")
+                .birthday(LocalDate.of(2000, 1, 1))
+                .build();
     }
 }


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
 본 PR은 사용자가 'AI 면접' 단계로 넘어가기 전, 필수 제출 서류(이력서, 자기소개서, 포트폴리오)의 작성 완료 여부를 클라이언트가 확인할 수 있도록 프로필 완성도 상태 조회 API를 추가하는 작업입니다.

더불어, 회원가입 시 필수값이 아닌 정보들을 조회 할 때 NPE 방지 로직을 추가 했습니다.

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
문서 작성 상태 조회 API 개발

- GET /api/applicants/document-status 엔드포인트 추가

     - ApplicantDocumentStatusResponseDTO 생성 (hasResume, hasCoverLetter, hasPortfolio 필드 포함)

     - 불필요한 전체 데이터 조회를 방지하기 위해 각 Repository에 existsByApplicant() 쿼리 메서드를 구현하여 DB 조회 성능 최적화

- ApplicantDetailResponseDTO에서 birthday가 null일 경우 .toString() 호출 시 발생하던 NullPointerException 방어 로직 추가 (삼항 연산자 적용)

- Swagger API 명세서 업데이트

     신규 API 명세 추가 및 birthday 필드 nullable = true 속성 반영


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 프론트엔드 렌더링 속도에 영향을 줄 수 있는 API이므로, 객체를 모두 끌어오지 않고 exists 쿼리로 boolean 값만 반환하도록 최적화했습니다. 로직상 혹시 더 개선할 부분이 있다면 코멘트 남겨주세요.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #93 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)