### PR TITLE
[FIX] CertificateUpdateDetailDTO 데이터 검증 어노테이션 수정 및 ApplicantDetailResponseDTO 응답값 추가

### DIFF
--- a/src/main/java/com/weiver/applicant/dto/request/put/CertificateUpdateDetailDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/request/put/CertificateUpdateDetailDTO.java
@@ -5,6 +5,7 @@ import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.domain.Certificate;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
@@ -15,7 +16,7 @@ public record CertificateUpdateDetailDTO(
         Long certificateId,
 
         @Schema(description = "취득 날짜", example = "2025-11-25", type = "string")
-        @NotBlank(message = "취득 날짜는 필수 입력값입니다.")
+        @NotNull(message = "취득 날짜는 필수 입력값입니다.")
         LocalDate acquisitionDate,
 
         @Schema(description = "자격증 이름", example = "SQLD")

--- a/src/main/java/com/weiver/applicant/dto/response/ApplicantDetailResponseDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/response/ApplicantDetailResponseDTO.java
@@ -12,6 +12,9 @@ public record ApplicantDetailResponseDTO(
         @Schema(description = "지원자 실명", example = "이현우")
         String name,
 
+        @Schema(description = "주소", example = "서울특별시 강남구 역삼동", nullable = true)
+        String address,
+
         @Schema(description = "생년월일 (YYYY-MM-DD 형식)", example = "2000-01-01", nullable = true)
         String birthday,
 
@@ -25,6 +28,7 @@ public record ApplicantDetailResponseDTO(
         return new ApplicantDetailResponseDTO(
                 applicant.getPhotoUrl(),
                 applicant.getName(),
+                applicant.getAddress() != null ? applicant.getAddress().toString() : null,
                 applicant.getBirthday() != null ? applicant.getBirthday().toString() : null,
                 applicant.getPhoneNumber(),
                 applicant.getEmail()

--- a/src/main/java/com/weiver/applicant/dto/response/ApplicantDetailResponseDTO.java
+++ b/src/main/java/com/weiver/applicant/dto/response/ApplicantDetailResponseDTO.java
@@ -28,7 +28,7 @@ public record ApplicantDetailResponseDTO(
         return new ApplicantDetailResponseDTO(
                 applicant.getPhotoUrl(),
                 applicant.getName(),
-                applicant.getAddress() != null ? applicant.getAddress().toString() : null,
+                applicant.getAddress() != null ? applicant.getAddress() : null,
                 applicant.getBirthday() != null ? applicant.getBirthday().toString() : null,
                 applicant.getPhoneNumber(),
                 applicant.getEmail()

--- a/src/test/java/com/weiver/applicant/controller/ApplicantControllerTest.java
+++ b/src/test/java/com/weiver/applicant/controller/ApplicantControllerTest.java
@@ -97,6 +97,7 @@ class ApplicantControllerTest {
         ApplicantDetailResponseDTO mockApplicantDetail = new ApplicantDetailResponseDTO(
                 "https://weiver-public-bucket.s3.ap-northeast-2.amazonaws.com",
                 "이현우",
+                "경기도 안산시 일동",
                 "2002-02-08",
                 "010-5622-5555",
                 "asdglk@gmail.com"


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
CertificateUpdateDetailDTO 데이터 검증 어노테이션 수정 및 ApplicantDetailResponseDTO 응답값 추가

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
1. CertificateUpdateDetailDTO
LocalDate acquisitionDate에 @NotBlank 말고 @NotNull로 변경 했습니다.

2. ApplicantDetailResponseDTO 
address 컬럼 추가하여 주소 데이터도 클라이언트가 확인 할 수 있게 변경했습니다. 

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #97 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applicant profiles now display complete address information in detail views, enabling users to access full location data alongside other applicant details.

* **Improvements**
  * Certificate acquisition date validation has been refined to strengthen data quality assurance and ensure consistent validation handling throughout certificate operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->