### PR TITLE
[FEATURE] 자기소개서 기획 변경으로 인한 Entity 변경 및 API 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       start_period: 30s
 
   weiver-redis:
-    image: redis:alpine
+    image: redis:7-alpine
     container_name: weiver-redis
     ports:
       - "6379:6379"

--- a/src/main/java/com/weiver/essay/controller/EssayAnswerController.java
+++ b/src/main/java/com/weiver/essay/controller/EssayAnswerController.java
@@ -15,7 +15,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "자기소개서(Essay) API", description = "구직자의 자기소개서 조회, 저장 및 수정 API입니다.")
 @RestController
@@ -27,14 +33,16 @@ public class EssayAnswerController {
 
     @Operation(
             summary = "자기소개서 초기 저장",
-            description = "구직자가 최초로 자기소개서를 작성하고 저장할 때 호출합니다.<br>" +
+            description = "각 문항의 고유 ID(questionId)와 작성한 answer를 배열(List)에 담아서 전송해야 합니다.<br>" +
                     "**주의:** 요청 헤더에 JWT Access Token이 포함되어야 하며, 해당 토큰의 구직자 ID로 매핑되어 저장됩니다."
     )
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> saveEssayanswer(
             @RequestBody @Valid EssayAnswerRequestDTO requestDTO,
             @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
-        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        if (principal == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
 
         essayAnswerService.saveEssayAnswer(requestDTO, principal.publicId());
         return ResponseEntity.ok(ApiResponse.success("자기소개서 저장 성공했습니다."));
@@ -42,15 +50,17 @@ public class EssayAnswerController {
 
     @Operation(
             summary = "자기소개서 내용 수정",
-            description = "이미 작성된 자기소개서의 내용을 수정합니다.<br>" +
-                    "**보안:** URL의 `answerId`와 현재 로그인한 사용자의 ID를 검증하여, 본인의 자기소개서만 수정할 수 있습니다."
+            description = "이미 작성한 자기소개서의 내용을 수정합니다.<br>" +
+                    "**보안:** URL의 `answerId`와 현재 로그인한 사용자의 ID를 검증하고, 본인의 자기소개서만 수정할 수 있습니다."
     )
     @PatchMapping("/{answerId}")
     public ResponseEntity<ApiResponse<Void>> updateEssayanswer(
             @RequestBody @Valid EssayAnswerUpdateRequestDTO requestDTO,
             @Parameter(description = "수정할 자기소개서의 고유 ID (PK)", example = "1") @PathVariable long answerId,
             @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
-        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        if (principal == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
 
         essayAnswerService.updateEssayAnswer(requestDTO, principal.publicId(), answerId);
 
@@ -59,12 +69,14 @@ public class EssayAnswerController {
 
     @Operation(
             summary = "내 자기소개서 조회",
-            description = "마이페이지 또는 자기소개서 관리 탭에서 현재 로그인한 구직자의 자기소개서 내용을 조회합니다."
+            description = "마이페이지 또는 자기소개서 관리 화면에서 현재 로그인한 구직자의 자기소개서 내용을 조회합니다."
     )
     @GetMapping
     public ResponseEntity<ApiResponse<EssayAnswerResponseDTO>> searchEssayanswer(
             @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
-        if(principal == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        if (principal == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
 
         EssayAnswerResponseDTO responseDTO = essayAnswerService.searchEssayAnswer(principal.publicId());
 

--- a/src/main/java/com/weiver/essay/controller/EssayAnswerController.java
+++ b/src/main/java/com/weiver/essay/controller/EssayAnswerController.java
@@ -16,9 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -49,36 +48,38 @@ public class EssayAnswerController {
     }
 
     @Operation(
-            summary = "자기소개서 내용 수정",
-            description = "이미 작성한 자기소개서의 내용을 수정합니다.<br>" +
-                    "**보안:** URL의 `answerId`와 현재 로그인한 사용자의 ID를 검증하고, 본인의 자기소개서만 수정할 수 있습니다."
+            summary = "자기소개서 전체 수정",
+            description = """
+                    UI 기획상 개별 문항 저장이나 자동 저장 기능이 없으므로 **PUT 방식을 통한 전체 덮어쓰기**로 동작합니다.
+
+                    **[필독 주의사항: 전체 덮어쓰기 방식]** 부분 수정이 불가능합니다. 내용이 변경되지 않은 문항을 포함하여, 화면에 존재하는 3개 문항의 모든 답변 데이터를 배열에 담아 한 번에 전송해야 합니다.
+                    """
     )
-    @PatchMapping("/{answerId}")
-    public ResponseEntity<ApiResponse<Void>> updateEssayanswer(
+    @PutMapping
+    public ResponseEntity<ApiResponse<Void>> updateEssayanswers(
             @RequestBody @Valid EssayAnswerUpdateRequestDTO requestDTO,
-            @Parameter(description = "수정할 자기소개서의 고유 ID (PK)", example = "1") @PathVariable long answerId,
             @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if (principal == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
 
-        essayAnswerService.updateEssayAnswer(requestDTO, principal.publicId(), answerId);
+        essayAnswerService.updateEssayAnswers(requestDTO, principal.publicId());
 
         return ResponseEntity.ok(ApiResponse.success("자기소개서 수정 성공했습니다."));
     }
 
     @Operation(
-            summary = "내 자기소개서 조회",
-            description = "마이페이지 또는 자기소개서 관리 화면에서 현재 로그인한 구직자의 자기소개서 내용을 조회합니다."
+            summary = "내 자기소개서 전체 조회",
+            description = "작성된 자기소개서 문항과 답변 리스트를 전체 조회합니다."
     )
     @GetMapping
-    public ResponseEntity<ApiResponse<EssayAnswerResponseDTO>> searchEssayanswer(
+    public ResponseEntity<ApiResponse<EssayAnswerResponseDTO>> getEssayAnswers(
             @AuthenticationPrincipal @Parameter(hidden = true) AuthenticatedPrincipal principal) {
         if (principal == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
 
-        EssayAnswerResponseDTO responseDTO = essayAnswerService.searchEssayAnswer(principal.publicId());
+        EssayAnswerResponseDTO responseDTO = essayAnswerService.getEssayAnswers(principal.publicId());
 
         return ResponseEntity.ok(ApiResponse.success(responseDTO));
     }

--- a/src/main/java/com/weiver/essay/domain/EssayAnswer.java
+++ b/src/main/java/com/weiver/essay/domain/EssayAnswer.java
@@ -2,7 +2,7 @@ package com.weiver.essay.domain;
 
 
 import com.weiver.applicant.domain.Applicant;
-import com.weiver.essay.dto.request.EssayAnswerUpdateRequestDTO;
+import com.weiver.essay.dto.request.EssayAnswerUpdateItemDTO;
 import com.weiver.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -36,10 +36,8 @@ public class EssayAnswer extends BaseTimeEntity {
     /**
      * 편의메소드
      * */
-    public void updateAnswer(EssayAnswerUpdateRequestDTO requestDTO){
-        if(requestDTO.answer() != null) {
-            this.answer = requestDTO.answer();
-        }
+    public void updateAnswer(EssayAnswerUpdateItemDTO requestDTO){
+        this.answer = requestDTO.answer();
     }
 
 }

--- a/src/main/java/com/weiver/essay/domain/EssayAnswer.java
+++ b/src/main/java/com/weiver/essay/domain/EssayAnswer.java
@@ -23,10 +23,15 @@ public class EssayAnswer extends BaseTimeEntity {
     @Column(name = "answer", columnDefinition = "TEXT", nullable = false)
     private String answer;  // 답변
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "applicant_id", nullable = false)
     @ToString.Exclude
     private Applicant applicant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    @ToString.Exclude
+    private EssayQuestion essayQuestion;
 
     /**
      * 편의메소드

--- a/src/main/java/com/weiver/essay/domain/EssayQuestion.java
+++ b/src/main/java/com/weiver/essay/domain/EssayQuestion.java
@@ -1,0 +1,27 @@
+package com.weiver.essay.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "essay_questions")
+public class EssayQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_id")
+    private Long questionId;
+
+    @Column(name = "sequence", nullable = false)
+    private Integer sequence;
+
+    @Column(name = "max_length", nullable = false)
+    private Integer maxLength;
+
+    @Column(name = "question", nullable = false)
+    private String question;
+}

--- a/src/main/java/com/weiver/essay/dto/request/EssayAnswerItemDTO.java
+++ b/src/main/java/com/weiver/essay/dto/request/EssayAnswerItemDTO.java
@@ -1,0 +1,16 @@
+package com.weiver.essay.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "자기소개서 문항별 답변 DTO")
+public record EssayAnswerItemDTO(
+        @Schema(description = "자기소개서 문항 고유 ID", example = "1")
+        @NotNull
+        Long questionId,
+
+        @Schema(description = "해당 문항에 작성한 답변", example = "지원 동기입니다.")
+        @NotBlank
+        String answer
+) {}

--- a/src/main/java/com/weiver/essay/dto/request/EssayAnswerRequestDTO.java
+++ b/src/main/java/com/weiver/essay/dto/request/EssayAnswerRequestDTO.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
@@ -19,6 +20,7 @@ public record EssayAnswerRequestDTO(
                         ]
                         """
         )
+        @Size(min = 3, max = 3)
         @NotEmpty
         List<@NotNull @Valid EssayAnswerItemDTO> answers
 ) {}

--- a/src/main/java/com/weiver/essay/dto/request/EssayAnswerRequestDTO.java
+++ b/src/main/java/com/weiver/essay/dto/request/EssayAnswerRequestDTO.java
@@ -1,19 +1,24 @@
 package com.weiver.essay.dto.request;
 
-import com.weiver.applicant.domain.Applicant;
-import com.weiver.essay.domain.EssayAnswer;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
 
 @Schema(description = "자기소개서 등록 요청 DTO")
-public record EssayAnswerRequestDTO (
-        @Schema(description = "자기소개 답변", example = "안녕하세요. 저는 자라나는 미래의 꿈나무 이현우..")
-        @NotBlank String answer
-){
-    public EssayAnswer toEntity(Applicant applicant){
-        return EssayAnswer.builder()
-                .answer(this.answer)
-                .applicant(applicant)
-                .build();
-    }
-}
+public record EssayAnswerRequestDTO(
+        @Schema(
+                description = "각 문항의 고유 ID(questionId)와 작성한 answer 목록",
+                example = """
+                        [
+                          {"questionId": 1, "answer": "지원 동기입니다."},
+                          {"questionId": 2, "answer": "직무 역량입니다."},
+                          {"questionId": 3, "answer": "입사 후 포부입니다."}
+                        ]
+                        """
+        )
+        @NotEmpty
+        List<@NotNull @Valid EssayAnswerItemDTO> answers
+) {}

--- a/src/main/java/com/weiver/essay/dto/request/EssayAnswerUpdateItemDTO.java
+++ b/src/main/java/com/weiver/essay/dto/request/EssayAnswerUpdateItemDTO.java
@@ -1,0 +1,16 @@
+package com.weiver.essay.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "자기소개서 문항별 수정 요청 DTO")
+public record EssayAnswerUpdateItemDTO(
+        @Schema(description = "답변 고유 ID", example = "1")
+        @NotNull
+        Long answerId,
+
+        @Schema(description = "수정할 답변 내용", example = "수정된 지원 동기입니다.")
+        @NotBlank
+        String answer
+) {}

--- a/src/main/java/com/weiver/essay/dto/request/EssayAnswerUpdateRequestDTO.java
+++ b/src/main/java/com/weiver/essay/dto/request/EssayAnswerUpdateRequestDTO.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
@@ -20,5 +21,6 @@ public record EssayAnswerUpdateRequestDTO(
                         """
         )
         @NotEmpty
+        @Size(min = 3, max = 3, message = "자기소개서 3개 문항의 전체 답변을 모두 전송해야 합니다.")
         List<@NotNull @Valid EssayAnswerUpdateItemDTO> answers
 ) {}

--- a/src/main/java/com/weiver/essay/dto/request/EssayAnswerUpdateRequestDTO.java
+++ b/src/main/java/com/weiver/essay/dto/request/EssayAnswerUpdateRequestDTO.java
@@ -1,10 +1,24 @@
 package com.weiver.essay.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "자기소개서 수정 요청 DTO")
+import java.util.List;
+
+@Schema(description = "자기소개서 전체 수정 요청 DTO")
 public record EssayAnswerUpdateRequestDTO(
-        @Schema(description = "자기소개 답변", example = "안녕하세요. 저는 자라나는 미래의 꿈나무 이현우..")
-        @NotBlank String answer
-){}
+        @Schema(
+                description = "수정할 문항별 답변 목록. 전체 덮어쓰기 방식이므로 화면에 존재하는 모든 답변을 전송해야 합니다.",
+                example = """
+                        [
+                          {"answerId": 1, "answer": "수정된 지원 동기입니다."},
+                          {"answerId": 2, "answer": "수정된 직무 역량입니다."},
+                          {"answerId": 3, "answer": "수정된 입사 후 포부입니다."}
+                        ]
+                        """
+        )
+        @NotEmpty
+        List<@NotNull @Valid EssayAnswerUpdateItemDTO> answers
+) {}

--- a/src/main/java/com/weiver/essay/dto/response/EssayAnswerItemResponseDTO.java
+++ b/src/main/java/com/weiver/essay/dto/response/EssayAnswerItemResponseDTO.java
@@ -1,0 +1,39 @@
+package com.weiver.essay.dto.response;
+
+import com.weiver.essay.domain.EssayAnswer;
+import com.weiver.essay.domain.EssayQuestion;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "자기소개서 문항별 답변 응답 DTO")
+public record EssayAnswerItemResponseDTO(
+        @Schema(description = "답변 고유 ID", example = "1")
+        Long answerId,
+
+        @Schema(description = "자기소개서 문항 고유 ID", example = "1")
+        Long questionId,
+
+        @Schema(description = "문항 번호", example = "1")
+        Integer sequence,
+
+        @Schema(description = "질문 내용", example = "지원 동기는 무엇인가요?")
+        String question,
+
+        @Schema(description = "최대 글자 수", example = "500")
+        Integer maxLength,
+
+        @Schema(description = "사용자가 작성한 답변", example = "지원 동기입니다.")
+        String answer
+) {
+    public static EssayAnswerItemResponseDTO from(EssayAnswer essayAnswer) {
+        EssayQuestion essayQuestion = essayAnswer.getEssayQuestion();
+
+        return new EssayAnswerItemResponseDTO(
+                essayAnswer.getAnswerId(),
+                essayQuestion.getQuestionId(),
+                essayQuestion.getSequence(),
+                essayQuestion.getQuestion(),
+                essayQuestion.getMaxLength(),
+                essayAnswer.getAnswer()
+        );
+    }
+}

--- a/src/main/java/com/weiver/essay/dto/response/EssayAnswerResponseDTO.java
+++ b/src/main/java/com/weiver/essay/dto/response/EssayAnswerResponseDTO.java
@@ -1,21 +1,11 @@
 package com.weiver.essay.dto.response;
 
-import com.weiver.essay.domain.EssayAnswer;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "자기소개서 응답 DTO")
+import java.util.List;
+
+@Schema(description = "자기소개서 답변 목록 응답 DTO")
 public record EssayAnswerResponseDTO(
-
-        @Schema(description = "자기소개서 ID", example = "1")
-        Long answerId,
-
-        @Schema(description = "자기소개서 답변 내용", example = "저는 B2B AI 면접 플랫폼 'Weiver'와 영화 추천 서비스 'Moov' 등 다양한 프로젝트를 통해 대용량 데이터 처리와 서버 안정성을 다지는 경험을 했습니다...")
-        String answer
-){
-    public static EssayAnswerResponseDTO from(EssayAnswer essayAnswer){
-        return new EssayAnswerResponseDTO(
-                essayAnswer.getAnswerId(),
-                essayAnswer.getAnswer()
-        );
-    }
-}
+        @Schema(description = "문항별 자기소개서 답변 목록")
+        List<EssayAnswerItemResponseDTO> answers
+) {}

--- a/src/main/java/com/weiver/essay/repository/EssayAnswerRepository.java
+++ b/src/main/java/com/weiver/essay/repository/EssayAnswerRepository.java
@@ -3,12 +3,24 @@ package com.weiver.essay.repository;
 import com.weiver.applicant.domain.Applicant;
 import com.weiver.essay.domain.EssayAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long> {
     Optional<EssayAnswer> findByApplicant(Applicant applicant);
     boolean existsByApplicant(Applicant applicant);
+
+    @Query("""
+            select ea
+            from EssayAnswer ea
+            join fetch ea.essayQuestion eq
+            where ea.applicant = :applicant
+            order by eq.sequence asc
+            """)
+    List<EssayAnswer> findAllByApplicantWithQuestionOrderBySequence(@Param("applicant") Applicant applicant);
 }

--- a/src/main/java/com/weiver/essay/repository/EssayAnswerRepository.java
+++ b/src/main/java/com/weiver/essay/repository/EssayAnswerRepository.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 
 @Repository
 public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long> {
-    Optional<EssayAnswer> findByApplicant(Applicant applicant);
     boolean existsByApplicant(Applicant applicant);
 
     @Query("""

--- a/src/main/java/com/weiver/essay/repository/EssayQuestionRepository.java
+++ b/src/main/java/com/weiver/essay/repository/EssayQuestionRepository.java
@@ -1,0 +1,9 @@
+package com.weiver.essay.repository;
+
+import com.weiver.essay.domain.EssayQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EssayQuestionRepository extends JpaRepository<EssayQuestion, Long> {
+}

--- a/src/main/java/com/weiver/essay/service/EssayAnswerService.java
+++ b/src/main/java/com/weiver/essay/service/EssayAnswerService.java
@@ -3,15 +3,20 @@ package com.weiver.essay.service;
 import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.essay.domain.EssayAnswer;
+import com.weiver.essay.domain.EssayQuestion;
+import com.weiver.essay.dto.request.EssayAnswerItemDTO;
 import com.weiver.essay.dto.request.EssayAnswerRequestDTO;
 import com.weiver.essay.dto.request.EssayAnswerUpdateRequestDTO;
 import com.weiver.essay.dto.response.EssayAnswerResponseDTO;
 import com.weiver.essay.repository.EssayAnswerRepository;
+import com.weiver.essay.repository.EssayQuestionRepository;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -20,14 +25,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class EssayAnswerService {
 
     private final EssayAnswerRepository essayAnswerRepository;
+    private final EssayQuestionRepository essayQuestionRepository;
     private final ApplicantRepository applicantRepository;
 
 
     public void saveEssayAnswer(EssayAnswerRequestDTO requestDTO, String publicId) {
         Applicant applicant = getApplicant(publicId);
-        EssayAnswer essayAnswer = requestDTO.toEntity(applicant);
 
-        essayAnswerRepository.save(essayAnswer);
+        List<EssayAnswer> essayAnswers = requestDTO.answers().stream()
+                .map(answerItem -> createEssayAnswer(answerItem, applicant))
+                .toList();
+
+        essayAnswerRepository.saveAll(essayAnswers);
     }
 
     public void updateEssayAnswer(EssayAnswerUpdateRequestDTO requestDTO, String publicId, long answerId) {
@@ -59,5 +68,16 @@ public class EssayAnswerService {
         Applicant applicant = applicantRepository.findByPublicId(publicId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
         return applicant;
+    }
+
+    private EssayAnswer createEssayAnswer(EssayAnswerItemDTO answerItem, Applicant applicant) {
+        EssayQuestion essayQuestion = essayQuestionRepository.findById(answerItem.questionId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESSAY_QUESTION_NOT_FOUND));
+
+        return EssayAnswer.builder()
+                .answer(answerItem.answer())
+                .applicant(applicant)
+                .essayQuestion(essayQuestion)
+                .build();
     }
 }

--- a/src/main/java/com/weiver/essay/service/EssayAnswerService.java
+++ b/src/main/java/com/weiver/essay/service/EssayAnswerService.java
@@ -34,6 +34,10 @@ public class EssayAnswerService {
     public void saveEssayAnswer(EssayAnswerRequestDTO requestDTO, String publicId) {
         Applicant applicant = getApplicant(publicId);
 
+        if (essayAnswerRepository.existsByApplicant(applicant)) {
+            throw new BusinessException(ErrorCode.ESSAY_ANSWER_ALREADY_EXISTS);
+        }
+
         List<EssayAnswer> essayAnswers = requestDTO.answers().stream()
                 .map(answerItem -> createEssayAnswer(answerItem, applicant))
                 .toList();

--- a/src/main/java/com/weiver/essay/service/EssayAnswerService.java
+++ b/src/main/java/com/weiver/essay/service/EssayAnswerService.java
@@ -19,6 +19,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -38,15 +42,35 @@ public class EssayAnswerService {
             throw new BusinessException(ErrorCode.ESSAY_ANSWER_ALREADY_EXISTS);
         }
 
+        Map<Long, EssayQuestion> requiredQuestionMap = getRequiredQuestionMap(requestDTO);
+
         List<EssayAnswer> essayAnswers = requestDTO.answers().stream()
-                .map(answerItem -> createEssayAnswer(answerItem, applicant))
+                .map(answerItem -> createEssayAnswer(answerItem, applicant, requiredQuestionMap.get(answerItem.questionId())))
                 .toList();
 
         essayAnswerRepository.saveAll(essayAnswers);
     }
 
     public void updateEssayAnswers(EssayAnswerUpdateRequestDTO requestDTO, String publicId) {
-        requestDTO.answers().forEach(answerItem -> updateEssayAnswer(answerItem, publicId));
+        Applicant applicant = getApplicant(publicId);
+        List<EssayAnswer> existingAnswers = essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant);
+        if (existingAnswers.isEmpty()) {
+            throw new BusinessException(ErrorCode.ESSAY_ANSWER_NOT_FOUND);
+        }
+
+        Map<Long, EssayAnswer> existingAnswerMap = existingAnswers.stream()
+                .collect(Collectors.toMap(EssayAnswer::getAnswerId, Function.identity()));
+
+        Set<Long> requestAnswerIds = requestDTO.answers().stream()
+                .map(EssayAnswerUpdateItemDTO::answerId)
+                .collect(Collectors.toSet());
+
+        if (requestAnswerIds.size() != requestDTO.answers().size()
+                || !requestAnswerIds.equals(existingAnswerMap.keySet())) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+
+        requestDTO.answers().forEach(answerItem -> updateAnswer(answerItem, existingAnswerMap.get(answerItem.answerId())));
     }
 
     @Transactional(readOnly = true)
@@ -71,9 +95,36 @@ public class EssayAnswerService {
         return applicant;
     }
 
-    private EssayAnswer createEssayAnswer(EssayAnswerItemDTO answerItem, Applicant applicant) {
-        EssayQuestion essayQuestion = essayQuestionRepository.findById(answerItem.questionId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.ESSAY_QUESTION_NOT_FOUND));
+    private Map<Long, EssayQuestion> getRequiredQuestionMap(EssayAnswerRequestDTO requestDTO) {
+        List<EssayQuestion> requiredQuestions = essayQuestionRepository.findAll();
+        if (requiredQuestions.isEmpty()) {
+            throw new BusinessException(ErrorCode.ESSAY_QUESTION_NOT_FOUND);
+        }
+
+        Map<Long, EssayQuestion> requiredQuestionMap = requiredQuestions.stream()
+                .collect(Collectors.toMap(EssayQuestion::getQuestionId, Function.identity()));
+
+        Set<Long> requestQuestionIds = requestDTO.answers().stream()
+                .map(EssayAnswerItemDTO::questionId)
+                .collect(Collectors.toSet());
+
+        if (requestQuestionIds.size() != requestDTO.answers().size()) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+
+        if (!requiredQuestionMap.keySet().containsAll(requestQuestionIds)) {
+            throw new BusinessException(ErrorCode.ESSAY_QUESTION_NOT_FOUND);
+        }
+
+        if (!requestQuestionIds.equals(requiredQuestionMap.keySet())) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+
+        return requiredQuestionMap;
+    }
+
+    private EssayAnswer createEssayAnswer(EssayAnswerItemDTO answerItem, Applicant applicant, EssayQuestion essayQuestion) {
+        validateAnswerLength(answerItem.answer(), essayQuestion);
 
         return EssayAnswer.builder()
                 .answer(answerItem.answer())
@@ -82,14 +133,14 @@ public class EssayAnswerService {
                 .build();
     }
 
-    private void updateEssayAnswer(EssayAnswerUpdateItemDTO answerItem, String publicId) {
-        EssayAnswer essayAnswer = essayAnswerRepository.findById(answerItem.answerId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.ESSAY_ANSWER_NOT_FOUND));
-
-        if (!essayAnswer.getApplicant().getPublicId().equals(publicId)) {
-            throw new BusinessException(ErrorCode.FORBIDDEN);
+    private void validateAnswerLength(String answer, EssayQuestion essayQuestion) {
+        if (answer == null || answer.length() > essayQuestion.getMaxLength()) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
         }
+    }
 
+    private void updateAnswer(EssayAnswerUpdateItemDTO answerItem, EssayAnswer essayAnswer) {
+        validateAnswerLength(answerItem.answer(), essayAnswer.getEssayQuestion());
         essayAnswer.updateAnswer(answerItem);
     }
 }

--- a/src/main/java/com/weiver/essay/service/EssayAnswerService.java
+++ b/src/main/java/com/weiver/essay/service/EssayAnswerService.java
@@ -6,7 +6,9 @@ import com.weiver.essay.domain.EssayAnswer;
 import com.weiver.essay.domain.EssayQuestion;
 import com.weiver.essay.dto.request.EssayAnswerItemDTO;
 import com.weiver.essay.dto.request.EssayAnswerRequestDTO;
+import com.weiver.essay.dto.request.EssayAnswerUpdateItemDTO;
 import com.weiver.essay.dto.request.EssayAnswerUpdateRequestDTO;
+import com.weiver.essay.dto.response.EssayAnswerItemResponseDTO;
 import com.weiver.essay.dto.response.EssayAnswerResponseDTO;
 import com.weiver.essay.repository.EssayAnswerRepository;
 import com.weiver.essay.repository.EssayQuestionRepository;
@@ -39,29 +41,24 @@ public class EssayAnswerService {
         essayAnswerRepository.saveAll(essayAnswers);
     }
 
-    public void updateEssayAnswer(EssayAnswerUpdateRequestDTO requestDTO, String publicId, long answerId) {
-
-        EssayAnswer essayAnswer = essayAnswerRepository.findById(answerId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ESSAY_ANSWER_NOT_FOUND));
-
-        if (!essayAnswer.getApplicant().getPublicId().equals(publicId)) {
-            throw new BusinessException(ErrorCode.FORBIDDEN);
-        }
-
-        if(requestDTO != null){
-            essayAnswer.updateAnswer(requestDTO);
-        }
+    public void updateEssayAnswers(EssayAnswerUpdateRequestDTO requestDTO, String publicId) {
+        requestDTO.answers().forEach(answerItem -> updateEssayAnswer(answerItem, publicId));
     }
 
     @Transactional(readOnly = true)
-    public EssayAnswerResponseDTO searchEssayAnswer(String publicId) {
+    public EssayAnswerResponseDTO getEssayAnswers(String publicId) {
         Applicant applicant = getApplicant(publicId);
 
-        EssayAnswer essayAnswer = essayAnswerRepository.findByApplicant(applicant)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ESSAY_ANSWER_NOT_FOUND));
+        List<EssayAnswer> essayAnswers = essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant);
+        if (essayAnswers.isEmpty()) {
+            throw new BusinessException(ErrorCode.ESSAY_ANSWER_NOT_FOUND);
+        }
 
-        EssayAnswerResponseDTO responseDTO = EssayAnswerResponseDTO.from(essayAnswer);
-        return responseDTO;
+        List<EssayAnswerItemResponseDTO> answers = essayAnswers.stream()
+                .map(EssayAnswerItemResponseDTO::from)
+                .toList();
+
+        return new EssayAnswerResponseDTO(answers);
     }
 
     private Applicant getApplicant(String publicId) {
@@ -79,5 +76,16 @@ public class EssayAnswerService {
                 .applicant(applicant)
                 .essayQuestion(essayQuestion)
                 .build();
+    }
+
+    private void updateEssayAnswer(EssayAnswerUpdateItemDTO answerItem, String publicId) {
+        EssayAnswer essayAnswer = essayAnswerRepository.findById(answerItem.answerId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ESSAY_ANSWER_NOT_FOUND));
+
+        if (!essayAnswer.getApplicant().getPublicId().equals(publicId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        essayAnswer.updateAnswer(answerItem);
     }
 }

--- a/src/main/java/com/weiver/global/exception/ErrorCode.java
+++ b/src/main/java/com/weiver/global/exception/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     // ===================== ESSAY-ANSWER =====================
     ESSAY_ANSWER_NOT_FOUND("ESSAY_ANSWER_NOT_FOUND", HttpStatus.NOT_FOUND, "자기소개서를 찾을 수 없습니다."),
     ESSAY_QUESTION_NOT_FOUND("ESSAY_QUESTION_NOT_FOUND", HttpStatus.NOT_FOUND, "자기소개서 문항을 찾을 수 없습니다."),
+    ESSAY_ANSWER_ALREADY_EXISTS("ESSAY_ANSWER_ALREADY_EXISTS", HttpStatus.CONFLICT, "이미 자기소개서가 존재합니다."),
 
     // ===================== NOTIFICATION =====================
     NOTIFICATION_NOT_FOUND("NOTIFICATION_NOT_FOUND", HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),

--- a/src/main/java/com/weiver/global/exception/ErrorCode.java
+++ b/src/main/java/com/weiver/global/exception/ErrorCode.java
@@ -60,6 +60,7 @@ public enum ErrorCode {
 
     // ===================== ESSAY-ANSWER =====================
     ESSAY_ANSWER_NOT_FOUND("ESSAY_ANSWER_NOT_FOUND", HttpStatus.NOT_FOUND, "자기소개서를 찾을 수 없습니다."),
+    ESSAY_QUESTION_NOT_FOUND("ESSAY_QUESTION_NOT_FOUND", HttpStatus.NOT_FOUND, "자기소개서 문항을 찾을 수 없습니다."),
 
     // ===================== NOTIFICATION =====================
     NOTIFICATION_NOT_FOUND("NOTIFICATION_NOT_FOUND", HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),

--- a/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
+++ b/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
@@ -48,36 +48,36 @@ class EssayAnswerServiceTest {
     @Test
     @DisplayName("자기소개서 답변 목록 저장 성공")
     void saveEssayAnswer_Success() {
-        // Given
         String publicId = "3333";
         Applicant applicant = createApplicant(publicId);
-        EssayQuestion question = createQuestion(1L, 1);
         EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
-                new EssayAnswerItemDTO(1L, "지원 동기입니다.")
+                new EssayAnswerItemDTO(1L, "answer 1"),
+                new EssayAnswerItemDTO(2L, "answer 2"),
+                new EssayAnswerItemDTO(3L, "answer 3")
         ));
 
         given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
-        given(essayQuestionRepository.findById(1L)).willReturn(Optional.of(question));
+        given(essayQuestionRepository.findAll()).willReturn(List.of(
+                createQuestion(1L, 1),
+                createQuestion(2L, 2),
+                createQuestion(3L, 3)
+        ));
 
-        // When
         essayAnswerService.saveEssayAnswer(requestDTO, publicId);
 
-        // Then
         verify(essayAnswerRepository, times(1)).saveAll(any());
     }
 
     @Test
     @DisplayName("존재하지 않는 구직자 ID로 자기소개서 저장 시 예외 발생")
     void saveEssayAnswer_ApplicantNotFound_ThrowsException() {
-        // Given
         String invalidPublicId = "2222";
         EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
-                new EssayAnswerItemDTO(1L, "지원 동기입니다.")
+                new EssayAnswerItemDTO(1L, "answer")
         ));
 
         given(applicantRepository.findByPublicId(invalidPublicId)).willReturn(Optional.empty());
 
-        // When & Then
         assertThatThrownBy(() -> essayAnswerService.saveEssayAnswer(requestDTO, invalidPublicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
@@ -87,17 +87,21 @@ class EssayAnswerServiceTest {
     @Test
     @DisplayName("존재하지 않는 문항 ID로 자기소개서 저장 시 예외 발생")
     void saveEssayAnswer_QuestionNotFound_ThrowsException() {
-        // Given
         String publicId = "3333";
         Applicant applicant = createApplicant(publicId);
         EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
-                new EssayAnswerItemDTO(999L, "지원 동기입니다.")
+                new EssayAnswerItemDTO(1L, "answer 1"),
+                new EssayAnswerItemDTO(2L, "answer 2"),
+                new EssayAnswerItemDTO(999L, "answer 3")
         ));
 
         given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
-        given(essayQuestionRepository.findById(999L)).willReturn(Optional.empty());
+        given(essayQuestionRepository.findAll()).willReturn(List.of(
+                createQuestion(1L, 1),
+                createQuestion(2L, 2),
+                createQuestion(3L, 3)
+        ));
 
-        // When & Then
         assertThatThrownBy(() -> essayAnswerService.saveEssayAnswer(requestDTO, publicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
@@ -105,43 +109,111 @@ class EssayAnswerServiceTest {
     }
 
     @Test
+    @DisplayName("저장 시 요청 문항 ID가 중복되면 예외 발생")
+    void saveEssayAnswer_DuplicateQuestionIds_ThrowsException() {
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+        EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
+                new EssayAnswerItemDTO(1L, "answer 1"),
+                new EssayAnswerItemDTO(1L, "answer 2"),
+                new EssayAnswerItemDTO(2L, "answer 3")
+        ));
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayQuestionRepository.findAll()).willReturn(List.of(
+                createQuestion(1L, 1),
+                createQuestion(2L, 2),
+                createQuestion(3L, 3)
+        ));
+
+        assertThatThrownBy(() -> essayAnswerService.saveEssayAnswer(requestDTO, publicId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("저장 시 필수 문항 전체가 포함되지 않으면 예외 발생")
+    void saveEssayAnswer_RequiredQuestionIdsMismatch_ThrowsException() {
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+        EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
+                new EssayAnswerItemDTO(1L, "answer 1"),
+                new EssayAnswerItemDTO(2L, "answer 2"),
+                new EssayAnswerItemDTO(4L, "answer 3")
+        ));
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayQuestionRepository.findAll()).willReturn(List.of(
+                createQuestion(1L, 1),
+                createQuestion(2L, 2),
+                createQuestion(4L, 4),
+                createQuestion(5L, 5)
+        ));
+
+        assertThatThrownBy(() -> essayAnswerService.saveEssayAnswer(requestDTO, publicId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("저장 시 답변이 문항 최대 길이를 초과하면 예외 발생")
+    void saveEssayAnswer_AnswerExceedsMaxLength_ThrowsException() {
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+        EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
+                new EssayAnswerItemDTO(1L, "123456"),
+                new EssayAnswerItemDTO(2L, "answer 2"),
+                new EssayAnswerItemDTO(3L, "answer 3")
+        ));
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayQuestionRepository.findAll()).willReturn(List.of(
+                createQuestion(1L, 1, 5),
+                createQuestion(2L, 2),
+                createQuestion(3L, 3)
+        ));
+
+        assertThatThrownBy(() -> essayAnswerService.saveEssayAnswer(requestDTO, publicId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+
+    @Test
     @DisplayName("자기소개서 문항과 답변 리스트 조회 성공")
     void getEssayAnswers_Success() {
-        // Given
         String publicId = "3333";
         Applicant applicant = createApplicant(publicId);
         EssayQuestion question1 = createQuestion(1L, 1);
         EssayQuestion question2 = createQuestion(2L, 2);
         List<EssayAnswer> essayAnswers = List.of(
-                createAnswer(10L, "지원 동기입니다.", applicant, question1),
-                createAnswer(11L, "직무 역량입니다.", applicant, question2)
+                createAnswer(10L, "answer 1", applicant, question1),
+                createAnswer(11L, "answer 2", applicant, question2)
         );
 
         given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
         given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant)).willReturn(essayAnswers);
 
-        // When
         EssayAnswerResponseDTO responseDTO = essayAnswerService.getEssayAnswers(publicId);
 
-        // Then
         assertThat(responseDTO.answers()).hasSize(2);
         assertThat(responseDTO.answers().get(0).answerId()).isEqualTo(10L);
         assertThat(responseDTO.answers().get(0).questionId()).isEqualTo(1L);
         assertThat(responseDTO.answers().get(0).sequence()).isEqualTo(1);
-        assertThat(responseDTO.answers().get(0).answer()).isEqualTo("지원 동기입니다.");
+        assertThat(responseDTO.answers().get(0).answer()).isEqualTo("answer 1");
     }
 
     @Test
     @DisplayName("작성된 자기소개서가 없으면 조회 시 예외 발생")
     void getEssayAnswers_NotWrittenYet_ThrowsException() {
-        // Given
         String publicId = "3333";
         Applicant applicant = createApplicant(publicId);
 
         given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
         given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant)).willReturn(List.of());
 
-        // When & Then
         assertThatThrownBy(() -> essayAnswerService.getEssayAnswers(publicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
@@ -151,56 +223,117 @@ class EssayAnswerServiceTest {
     @Test
     @DisplayName("자기소개서 전체 수정 성공")
     void updateEssayAnswers_Success() {
-        // Given
         String publicId = "3333";
         Applicant applicant = createApplicant(publicId);
-        EssayQuestion question = createQuestion(1L, 1);
-        EssayAnswer essayAnswer = createAnswer(10L, "기존 답변입니다.", applicant, question);
+        EssayAnswer essayAnswer1 = createAnswer(10L, "old answer 1", applicant, createQuestion(1L, 1));
+        EssayAnswer essayAnswer2 = createAnswer(11L, "old answer 2", applicant, createQuestion(2L, 2));
+        EssayAnswer essayAnswer3 = createAnswer(12L, "old answer 3", applicant, createQuestion(3L, 3));
         EssayAnswerUpdateRequestDTO requestDTO = new EssayAnswerUpdateRequestDTO(List.of(
-                new EssayAnswerUpdateItemDTO(10L, "수정된 답변입니다.")
+                new EssayAnswerUpdateItemDTO(10L, "new answer 1"),
+                new EssayAnswerUpdateItemDTO(11L, "new answer 2"),
+                new EssayAnswerUpdateItemDTO(12L, "new answer 3")
         ));
 
-        given(essayAnswerRepository.findById(10L)).willReturn(Optional.of(essayAnswer));
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant))
+                .willReturn(List.of(essayAnswer1, essayAnswer2, essayAnswer3));
 
-        // When
         essayAnswerService.updateEssayAnswers(requestDTO, publicId);
 
-        // Then
-        assertThat(essayAnswer.getAnswer()).isEqualTo("수정된 답변입니다.");
+        assertThat(essayAnswer1.getAnswer()).isEqualTo("new answer 1");
+        assertThat(essayAnswer2.getAnswer()).isEqualTo("new answer 2");
+        assertThat(essayAnswer3.getAnswer()).isEqualTo("new answer 3");
     }
 
     @Test
-    @DisplayName("다른 구직자의 자기소개서 수정 시 예외 발생")
-    void updateEssayAnswers_Forbidden_ThrowsException() {
-        // Given
-        Applicant owner = createApplicant("3333");
-        EssayQuestion question = createQuestion(1L, 1);
-        EssayAnswer essayAnswer = createAnswer(10L, "기존 답변입니다.", owner, question);
+    @DisplayName("요청 답변 ID가 기존 답변 ID 전체와 다르면 예외 발생")
+    void updateEssayAnswers_MismatchedAnswerIds_ThrowsException() {
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+        List<EssayAnswer> existingAnswers = List.of(
+                createAnswer(10L, "old answer 1", applicant, createQuestion(1L, 1)),
+                createAnswer(11L, "old answer 2", applicant, createQuestion(2L, 2)),
+                createAnswer(12L, "old answer 3", applicant, createQuestion(3L, 3))
+        );
         EssayAnswerUpdateRequestDTO requestDTO = new EssayAnswerUpdateRequestDTO(List.of(
-                new EssayAnswerUpdateItemDTO(10L, "해커가 바꾼 내용")
+                new EssayAnswerUpdateItemDTO(10L, "new answer 1"),
+                new EssayAnswerUpdateItemDTO(11L, "new answer 2"),
+                new EssayAnswerUpdateItemDTO(999L, "new answer 3")
         ));
 
-        given(essayAnswerRepository.findById(10L)).willReturn(Optional.of(essayAnswer));
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant)).willReturn(existingAnswers);
 
-        // When & Then
-        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswers(requestDTO, "2222"))
+        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswers(requestDTO, publicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
-                .isEqualTo(ErrorCode.FORBIDDEN);
+                .isEqualTo(ErrorCode.BAD_REQUEST);
     }
 
     @Test
-    @DisplayName("존재하지 않는 답변 ID 수정 시 예외 발생")
-    void updateEssayAnswers_EssayNotFound_ThrowsException() {
-        // Given
+    @DisplayName("요청 답변 ID가 중복되면 예외 발생")
+    void updateEssayAnswers_DuplicateAnswerIds_ThrowsException() {
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+        List<EssayAnswer> existingAnswers = List.of(
+                createAnswer(10L, "old answer 1", applicant, createQuestion(1L, 1)),
+                createAnswer(11L, "old answer 2", applicant, createQuestion(2L, 2)),
+                createAnswer(12L, "old answer 3", applicant, createQuestion(3L, 3))
+        );
         EssayAnswerUpdateRequestDTO requestDTO = new EssayAnswerUpdateRequestDTO(List.of(
-                new EssayAnswerUpdateItemDTO(999L, "수정할 내용")
+                new EssayAnswerUpdateItemDTO(10L, "new answer 1"),
+                new EssayAnswerUpdateItemDTO(10L, "new answer 2"),
+                new EssayAnswerUpdateItemDTO(11L, "new answer 3")
         ));
 
-        given(essayAnswerRepository.findById(999L)).willReturn(Optional.empty());
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant)).willReturn(existingAnswers);
 
-        // When & Then
-        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswers(requestDTO, "3333"))
+        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswers(requestDTO, publicId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("수정 시 답변이 문항 최대 길이를 초과하면 예외 발생")
+    void updateEssayAnswers_AnswerExceedsMaxLength_ThrowsException() {
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+        EssayAnswer essayAnswer1 = createAnswer(10L, "old answer 1", applicant, createQuestion(1L, 1, 5));
+        EssayAnswer essayAnswer2 = createAnswer(11L, "old answer 2", applicant, createQuestion(2L, 2, 20));
+        EssayAnswer essayAnswer3 = createAnswer(12L, "old answer 3", applicant, createQuestion(3L, 3, 20));
+        EssayAnswerUpdateRequestDTO requestDTO = new EssayAnswerUpdateRequestDTO(List.of(
+                new EssayAnswerUpdateItemDTO(10L, "123456"),
+                new EssayAnswerUpdateItemDTO(11L, "new answer 2"),
+                new EssayAnswerUpdateItemDTO(12L, "new answer 3")
+        ));
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant))
+                .willReturn(List.of(essayAnswer1, essayAnswer2, essayAnswer3));
+
+        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswers(requestDTO, publicId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("작성된 자기소개서가 없으면 수정 시 예외 발생")
+    void updateEssayAnswers_NotWrittenYet_ThrowsException() {
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+        EssayAnswerUpdateRequestDTO requestDTO = new EssayAnswerUpdateRequestDTO(List.of(
+                new EssayAnswerUpdateItemDTO(10L, "new answer 1"),
+                new EssayAnswerUpdateItemDTO(11L, "new answer 2"),
+                new EssayAnswerUpdateItemDTO(12L, "new answer 3")
+        ));
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant)).willReturn(List.of());
+
+        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswers(requestDTO, publicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(ErrorCode.ESSAY_ANSWER_NOT_FOUND);
@@ -214,11 +347,15 @@ class EssayAnswerServiceTest {
     }
 
     private EssayQuestion createQuestion(Long questionId, Integer sequence) {
+        return createQuestion(questionId, sequence, 500);
+    }
+
+    private EssayQuestion createQuestion(Long questionId, Integer sequence, Integer maxLength) {
         return EssayQuestion.builder()
                 .questionId(questionId)
                 .sequence(sequence)
-                .maxLength(500)
-                .question(sequence + "번 문항")
+                .maxLength(maxLength)
+                .question(sequence + " question")
                 .build();
     }
 

--- a/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
+++ b/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
@@ -6,6 +6,7 @@ import com.weiver.essay.domain.EssayAnswer;
 import com.weiver.essay.domain.EssayQuestion;
 import com.weiver.essay.dto.request.EssayAnswerItemDTO;
 import com.weiver.essay.dto.request.EssayAnswerRequestDTO;
+import com.weiver.essay.dto.request.EssayAnswerUpdateItemDTO;
 import com.weiver.essay.dto.request.EssayAnswerUpdateRequestDTO;
 import com.weiver.essay.dto.response.EssayAnswerResponseDTO;
 import com.weiver.essay.repository.EssayAnswerRepository;
@@ -45,28 +46,18 @@ class EssayAnswerServiceTest {
     private EssayAnswerService essayAnswerService;
 
     @Test
-    @DisplayName("자기소개서 저장 정상 수행")
+    @DisplayName("자기소개서 답변 목록 저장 성공")
     void saveEssayAnswer_Success() {
         // Given
-        long applicantId = 1L;
         String publicId = "3333";
-        Applicant applicant = Applicant.builder()
-                .applicantId(applicantId)
-                .publicId(publicId)
-                .build();
-        long questionId = 1L;
-        EssayQuestion essayQuestion = EssayQuestion.builder()
-                .questionId(questionId)
-                .sequence(1)
-                .maxLength(500)
-                .question("지원 동기는 무엇인가요?")
-                .build();
+        Applicant applicant = createApplicant(publicId);
+        EssayQuestion question = createQuestion(1L, 1);
         EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
-                new EssayAnswerItemDTO(questionId, "안녕. 날 뽑아봐.")
+                new EssayAnswerItemDTO(1L, "지원 동기입니다.")
         ));
 
         given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
-        given(essayQuestionRepository.findById(questionId)).willReturn(Optional.of(essayQuestion));
+        given(essayQuestionRepository.findById(1L)).willReturn(Optional.of(question));
 
         // When
         essayAnswerService.saveEssayAnswer(requestDTO, publicId);
@@ -76,96 +67,7 @@ class EssayAnswerServiceTest {
     }
 
     @Test
-    @DisplayName("자기소개서 수정 정상 수행")
-    void updateEssayAnswer_Success() {
-        // Given
-        long applicantId = 1L;
-        long answerId = 100L;
-        String publicId = "3333";
-
-        Applicant me = Applicant.builder()
-                .applicantId(applicantId)
-                .publicId(publicId)
-                .build();
-
-        EssayAnswer myEssay = EssayAnswer.builder()
-                .answerId(answerId)
-                .answer("안녕. 날 뽑아봐.")
-                .applicant(me)
-                .build();
-
-        EssayAnswerUpdateRequestDTO updateDTO = new EssayAnswerUpdateRequestDTO("안녕, 나 수정했어.");
-
-        given(essayAnswerRepository.findById(answerId)).willReturn(Optional.of(myEssay));
-
-        // When
-        essayAnswerService.updateEssayAnswer(updateDTO, publicId, answerId);
-
-        // Then
-        assertThat(myEssay.getAnswer()).isEqualTo("안녕, 나 수정했어.");
-    }
-
-    @Test
-    @DisplayName("자기소개서 수정 예외 발생 - 다른 사람의 자소서를 수정하려고 할 때 (FORBIDDEN)")
-    void updateEssayAnswer_Forbidden_ThrowsException() {
-        // Given
-        long myApplicantId = 1L;
-        String myPublicId = "3333";
-        String hackerPublicId = "2222";
-        long answerId = 100L;
-
-        Applicant me = Applicant.builder()
-                .applicantId(myApplicantId)
-                .publicId(myPublicId)
-                .build();
-
-        // 진짜 주인이 있는 자소서 객체 생성
-        EssayAnswer myEssay = EssayAnswer.builder()
-                .answerId(answerId)
-                .answer("내 소중한 자소서")
-                .applicant(me)
-                .build();
-
-        EssayAnswerUpdateRequestDTO updateDTO = new EssayAnswerUpdateRequestDTO("해커가 마음대로 바꾼 내용");
-
-        given(essayAnswerRepository.findById(answerId)).willReturn(Optional.of(myEssay));
-
-        // When & Then
-        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswer(updateDTO, hackerPublicId, answerId))
-                .isInstanceOf(BusinessException.class)
-                .extracting("code")
-                .isEqualTo(ErrorCode.FORBIDDEN);
-    }
-
-    @Test
-    @DisplayName("자기소개서 조회 정상 수행")
-    void searchEssayAnswer_Success() {
-        // Given
-        long applicantId = 1L;
-        String publicId = "3333";
-        Applicant applicant = Applicant.builder()
-                .applicantId(applicantId)
-                .publicId(publicId)
-                .build();
-
-        EssayAnswer essayAnswer = EssayAnswer.builder()
-                .answerId(10L)
-                .answer("이것은 내 자소서입니다.")
-                .applicant(applicant)
-                .build();
-
-        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
-        given(essayAnswerRepository.findByApplicant(applicant)).willReturn(Optional.of(essayAnswer));
-
-        // When
-        EssayAnswerResponseDTO responseDTO = essayAnswerService.searchEssayAnswer(publicId);
-
-        // Then
-        assertThat(responseDTO.answer()).isEqualTo("이것은 내 자소서입니다.");
-    }
-
-    @Test
-    @DisplayName("엣지 케이스: 존재하지 않는 회원의 ID로 자소서 저장 시 APPLICANT_NOT_FOUND 예외 발생")
+    @DisplayName("존재하지 않는 구직자 ID로 자기소개서 저장 시 예외 발생")
     void saveEssayAnswer_ApplicantNotFound_ThrowsException() {
         // Given
         String invalidPublicId = "2222";
@@ -175,7 +77,7 @@ class EssayAnswerServiceTest {
 
         given(applicantRepository.findByPublicId(invalidPublicId)).willReturn(Optional.empty());
 
-        // When & Then!
+        // When & Then
         assertThatThrownBy(() -> essayAnswerService.saveEssayAnswer(requestDTO, invalidPublicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
@@ -183,72 +85,149 @@ class EssayAnswerServiceTest {
     }
 
     @Test
-    @DisplayName("엣지 케이스: 존재하지 않는 자소서를 수정하려고 할 때 ESSAY_ANSWER_NOT_FOUND 예외 발생")
-    void updateEssayAnswer_EssayNotFound_ThrowsException() {
+    @DisplayName("존재하지 않는 문항 ID로 자기소개서 저장 시 예외 발생")
+    void saveEssayAnswer_QuestionNotFound_ThrowsException() {
         // Given
         String publicId = "3333";
-        long invalidAnswerId = 999L;
-        EssayAnswerUpdateRequestDTO updateDTO = new EssayAnswerUpdateRequestDTO("수정할 내용");
-
-        given(essayAnswerRepository.findById(invalidAnswerId)).willReturn(Optional.empty());
-
-        // When & Then
-        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswer(updateDTO, publicId, invalidAnswerId))
-                .isInstanceOf(BusinessException.class)
-                .extracting("code")
-                .isEqualTo(ErrorCode.ESSAY_ANSWER_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("엣지 케이스: 자소서 수정 시 DTO의 내용이 null일 경우 기존 데이터를 덮어 씌우면 안됨")
-    void updateEssayAnswer_NullContent_KeepsExistingData() {
-        // Given
-        long applicantId = 1L;
-        String publicId = "3333";
-        long answerId = 100L;
-        Applicant me = Applicant.builder()
-                .applicantId(applicantId)
-                .publicId(publicId)
-                .build();
-
-        // 기존 자소서 내용
-        EssayAnswer myEssay = EssayAnswer.builder()
-                .answerId(answerId)
-                .answer("내 소중한 기존 자소서 내용")
-                .applicant(me)
-                .build();
-
-        EssayAnswerUpdateRequestDTO nullUpdateDTO = new EssayAnswerUpdateRequestDTO(null);
-
-        given(essayAnswerRepository.findById(answerId)).willReturn(Optional.of(myEssay));
-
-        // When
-        essayAnswerService.updateEssayAnswer(nullUpdateDTO, publicId, answerId);
-
-        // Then
-        assertThat(myEssay.getAnswer()).isEqualTo("내 소중한 기존 자소서 내용");
-    }
-
-    @Test
-    @DisplayName("엣지 케이스: 회원은 존재하지만, " +
-            "아직 자소서를 한 번도 작성하지 않은 상태에서 조회 시 ESSAY_ANSWER_NOT_FOUND 예외 발생")
-    void searchEssayAnswer_NotWrittenYet_ThrowsException() {
-        // Given
-        long applicantId = 1L;
-        String publicId = "3333";
-        Applicant applicant = Applicant.builder()
-                .applicantId(applicantId)
-                .publicId(publicId)
-                .build();
+        Applicant applicant = createApplicant(publicId);
+        EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
+                new EssayAnswerItemDTO(999L, "지원 동기입니다.")
+        ));
 
         given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
-
-        given(essayAnswerRepository.findByApplicant(applicant)).willReturn(Optional.empty());
+        given(essayQuestionRepository.findById(999L)).willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> essayAnswerService.searchEssayAnswer(publicId))
+        assertThatThrownBy(() -> essayAnswerService.saveEssayAnswer(requestDTO, publicId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.ESSAY_QUESTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("자기소개서 문항과 답변 리스트 조회 성공")
+    void getEssayAnswers_Success() {
+        // Given
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+        EssayQuestion question1 = createQuestion(1L, 1);
+        EssayQuestion question2 = createQuestion(2L, 2);
+        List<EssayAnswer> essayAnswers = List.of(
+                createAnswer(10L, "지원 동기입니다.", applicant, question1),
+                createAnswer(11L, "직무 역량입니다.", applicant, question2)
+        );
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant)).willReturn(essayAnswers);
+
+        // When
+        EssayAnswerResponseDTO responseDTO = essayAnswerService.getEssayAnswers(publicId);
+
+        // Then
+        assertThat(responseDTO.answers()).hasSize(2);
+        assertThat(responseDTO.answers().get(0).answerId()).isEqualTo(10L);
+        assertThat(responseDTO.answers().get(0).questionId()).isEqualTo(1L);
+        assertThat(responseDTO.answers().get(0).sequence()).isEqualTo(1);
+        assertThat(responseDTO.answers().get(0).answer()).isEqualTo("지원 동기입니다.");
+    }
+
+    @Test
+    @DisplayName("작성된 자기소개서가 없으면 조회 시 예외 발생")
+    void getEssayAnswers_NotWrittenYet_ThrowsException() {
+        // Given
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+
+        given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant)).willReturn(List.of());
+
+        // When & Then
+        assertThatThrownBy(() -> essayAnswerService.getEssayAnswers(publicId))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(ErrorCode.ESSAY_ANSWER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("자기소개서 전체 수정 성공")
+    void updateEssayAnswers_Success() {
+        // Given
+        String publicId = "3333";
+        Applicant applicant = createApplicant(publicId);
+        EssayQuestion question = createQuestion(1L, 1);
+        EssayAnswer essayAnswer = createAnswer(10L, "기존 답변입니다.", applicant, question);
+        EssayAnswerUpdateRequestDTO requestDTO = new EssayAnswerUpdateRequestDTO(List.of(
+                new EssayAnswerUpdateItemDTO(10L, "수정된 답변입니다.")
+        ));
+
+        given(essayAnswerRepository.findById(10L)).willReturn(Optional.of(essayAnswer));
+
+        // When
+        essayAnswerService.updateEssayAnswers(requestDTO, publicId);
+
+        // Then
+        assertThat(essayAnswer.getAnswer()).isEqualTo("수정된 답변입니다.");
+    }
+
+    @Test
+    @DisplayName("다른 구직자의 자기소개서 수정 시 예외 발생")
+    void updateEssayAnswers_Forbidden_ThrowsException() {
+        // Given
+        Applicant owner = createApplicant("3333");
+        EssayQuestion question = createQuestion(1L, 1);
+        EssayAnswer essayAnswer = createAnswer(10L, "기존 답변입니다.", owner, question);
+        EssayAnswerUpdateRequestDTO requestDTO = new EssayAnswerUpdateRequestDTO(List.of(
+                new EssayAnswerUpdateItemDTO(10L, "해커가 바꾼 내용")
+        ));
+
+        given(essayAnswerRepository.findById(10L)).willReturn(Optional.of(essayAnswer));
+
+        // When & Then
+        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswers(requestDTO, "2222"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 답변 ID 수정 시 예외 발생")
+    void updateEssayAnswers_EssayNotFound_ThrowsException() {
+        // Given
+        EssayAnswerUpdateRequestDTO requestDTO = new EssayAnswerUpdateRequestDTO(List.of(
+                new EssayAnswerUpdateItemDTO(999L, "수정할 내용")
+        ));
+
+        given(essayAnswerRepository.findById(999L)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> essayAnswerService.updateEssayAnswers(requestDTO, "3333"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.ESSAY_ANSWER_NOT_FOUND);
+    }
+
+    private Applicant createApplicant(String publicId) {
+        return Applicant.builder()
+                .applicantId(1L)
+                .publicId(publicId)
+                .build();
+    }
+
+    private EssayQuestion createQuestion(Long questionId, Integer sequence) {
+        return EssayQuestion.builder()
+                .questionId(questionId)
+                .sequence(sequence)
+                .maxLength(500)
+                .question(sequence + "번 문항")
+                .build();
+    }
+
+    private EssayAnswer createAnswer(Long answerId, String answer, Applicant applicant, EssayQuestion essayQuestion) {
+        return EssayAnswer.builder()
+                .answerId(answerId)
+                .answer(answer)
+                .applicant(applicant)
+                .essayQuestion(essayQuestion)
+                .build();
     }
 }

--- a/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
+++ b/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
@@ -3,10 +3,13 @@ package com.weiver.essay.service;
 import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.essay.domain.EssayAnswer;
+import com.weiver.essay.domain.EssayQuestion;
+import com.weiver.essay.dto.request.EssayAnswerItemDTO;
 import com.weiver.essay.dto.request.EssayAnswerRequestDTO;
 import com.weiver.essay.dto.request.EssayAnswerUpdateRequestDTO;
 import com.weiver.essay.dto.response.EssayAnswerResponseDTO;
 import com.weiver.essay.repository.EssayAnswerRepository;
+import com.weiver.essay.repository.EssayQuestionRepository;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +34,9 @@ class EssayAnswerServiceTest {
 
     @Mock
     private EssayAnswerRepository essayAnswerRepository;
+
+    @Mock
+    private EssayQuestionRepository essayQuestionRepository;
 
     @Mock
     private ApplicantRepository applicantRepository;
@@ -47,15 +54,25 @@ class EssayAnswerServiceTest {
                 .applicantId(applicantId)
                 .publicId(publicId)
                 .build();
-        EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO("안녕. 날 뽑아봐.");
+        long questionId = 1L;
+        EssayQuestion essayQuestion = EssayQuestion.builder()
+                .questionId(questionId)
+                .sequence(1)
+                .maxLength(500)
+                .question("지원 동기는 무엇인가요?")
+                .build();
+        EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
+                new EssayAnswerItemDTO(questionId, "안녕. 날 뽑아봐.")
+        ));
 
         given(applicantRepository.findByPublicId(publicId)).willReturn(Optional.of(applicant));
+        given(essayQuestionRepository.findById(questionId)).willReturn(Optional.of(essayQuestion));
 
         // When
         essayAnswerService.saveEssayAnswer(requestDTO, publicId);
 
         // Then
-        verify(essayAnswerRepository, times(1)).save(any(EssayAnswer.class));
+        verify(essayAnswerRepository, times(1)).saveAll(any());
     }
 
     @Test
@@ -152,7 +169,9 @@ class EssayAnswerServiceTest {
     void saveEssayAnswer_ApplicantNotFound_ThrowsException() {
         // Given
         String invalidPublicId = "2222";
-        EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO("지원 동기입니다.");
+        EssayAnswerRequestDTO requestDTO = new EssayAnswerRequestDTO(List.of(
+                new EssayAnswerItemDTO(1L, "지원 동기입니다.")
+        ));
 
         given(applicantRepository.findByPublicId(invalidPublicId)).willReturn(Optional.empty());
 


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
본 PR은 변경된 자기소개서 기획(3개의 고정된 문항을 한 번에 작성 및 저장)과 ERD 구조에 맞춰, 자기소개서(Essay) 도메인의 엔티티 연관관계를 바로잡고 CRUD API를 전면 개편하는 작업입니다.

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 엔티티 연관관계 및 안전성 수정 (EssayAnswer.java)
     - 자식 엔티티에서 부모를 지워버릴 위험이 있던 CascadeType.ALL 설정 제거
     - EssayQuestion과의 연관관계를 @OneToOne에서 @ManyToOne으로 수정하여 1개의 질문에 N명의 답변이 달릴 수 있도록 정상화

- 자기소개서 작성 (POST) API 수정
     - 단일 텍스트 입력 방식에서 questionId와 answer를 묶은 배열(List) 형태로 한 번에 입력받아 일괄 저장(saveAll)하도록 변경

- 자기소개서 조회 (GET) API 수정
     - 구직자가 작성한 답변 리스트를 질문 정보와 함께 페치 조인(Fetch Join)하여 문항 번호(sequence) 오름차순으로 정렬 후 배열 형태로 반환

- 자기소개서 수정 (PUT) API 수정
     - 개별 저장/자동 저장 기획이 없으므로, 배열 데이터를 받아 기존 답변을 일괄 업데이트하는 전체 덮어쓰기(Full Overwrite) 방식으로 구현 (더티 체킹 활용)

- Swagger API 명세서 업데이트
     - 각 API의 데이터 전송 형식(배열) 명시 및 PUT API 사용 시 "부분 수정 불가, 전체 데이터 전송 필수"라는 주의사항 추가

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 해당 API들을 로컬에서 정상적으로 테스트하려면 essay_questions 테이블에 3개의 기본 질문 데이터가 미리 들어있어야 합니다. 

`INSERT INTO essay_questions (sequence, max_length, question) VALUES 
(1, 1000, '원하는 분야에 관심을 갖게 된 계기와 자신 있는 이유(그동안의 노력, 경험, 강점 포함) 등에 대해 구체적으로 설명해주세요.'),
(2, 1000, '가장 열정을 가지고 임했던 프로젝트(목표/과제 등)를 소개해주시고, 해당 프로젝트의 수행 과정 및 결과에 대해 기재해주세요.'),
(3, 500, '입사 후 회사에서 이루고 싶은 꿈을 적어주세요.');`

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<p>
1. POST 
<img width="1970" height="1294" alt="스크린샷 2026-06-13 182249" src="https://github.com/user-attachments/assets/672af9dd-75f1-484e-8938-3292af4cd2ab" />
<br>
<img width="1924" height="508" alt="스크린샷 2026-06-13 182312" src="https://github.com/user-attachments/assets/38ac540a-89d1-4aab-bcab-24bb5a0cc868" />
</p>

<p>
2. GET
<img width="1896" height="1464" alt="스크린샷 2026-06-13 184008" src="https://github.com/user-attachments/assets/f8d866a3-f625-4ef5-b505-9828c57658bb" />

</p>

<p>
3. PUT
<img width="1722" height="1306" alt="스크린샷 2026-06-13 184400" src="https://github.com/user-attachments/assets/e4c13191-1f9b-4907-bb7a-429385b3136e" />

<br>
<img width="1472" height="656" alt="스크린샷 2026-06-13 184420" src="https://github.com/user-attachments/assets/3029a1a9-a8d8-463c-ba80-c845a39b106d" />

</p>

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->

- close #100 


## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Essay answers now accept and return answers for multiple questions (per-question items) instead of a single answer.
  * Retrieval is ordered by the question sequence.
* **API Changes**
  * Updated the essay-answers API to use bulk, list-based request/response payloads.
  * Update and retrieval endpoints were renamed/rewired, with full overwrite semantics.
  * Added a clearer “essay question not found” error when referenced questions are missing.
* **Chores**
  * Updated Redis Docker image to version 7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->