### PR TITLE
[FEATURE] 테스트용 이메일 인증 우회 기능 추가

### DIFF
--- a/src/main/java/com/weiver/auth/service/ApplicantAuthService.java
+++ b/src/main/java/com/weiver/auth/service/ApplicantAuthService.java
@@ -36,7 +36,7 @@ public class ApplicantAuthService {
     private static final Duration VERIFICATION_TOKEN_TTL = Duration.ofMinutes(30);
     private static final Duration SIGNUP_TOKEN_TTL = Duration.ofMinutes(30);
     private static final int MAX_VERIFICATION_ATTEMPTS = 5;
-    // TODO(#99): 프론트엔드/QA 테스트용 임시 이메일 인증 우회 로직입니다.
+
     // 배포 이후 테스트 우회가 필요 없어지면 TEST_EMAIL_* 상수, isTestEmail(), send/verify 분기, 관련 테스트를 함께 삭제하세요.
     private static final String TEST_EMAIL_DOMAIN = "weiver.test";
     private static final String TEST_EMAIL_VERIFICATION_CODE = "000000";

--- a/src/main/java/com/weiver/auth/service/ApplicantAuthService.java
+++ b/src/main/java/com/weiver/auth/service/ApplicantAuthService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.Locale;
 import java.util.UUID;
 
 @Service
@@ -35,6 +36,10 @@ public class ApplicantAuthService {
     private static final Duration VERIFICATION_TOKEN_TTL = Duration.ofMinutes(30);
     private static final Duration SIGNUP_TOKEN_TTL = Duration.ofMinutes(30);
     private static final int MAX_VERIFICATION_ATTEMPTS = 5;
+    // TODO(#99): 프론트엔드/QA 테스트용 임시 이메일 인증 우회 로직입니다.
+    // 배포 이후 테스트 우회가 필요 없어지면 TEST_EMAIL_* 상수, isTestEmail(), send/verify 분기, 관련 테스트를 함께 삭제하세요.
+    private static final String TEST_EMAIL_DOMAIN = "weiver.test";
+    private static final String TEST_EMAIL_VERIFICATION_CODE = "000000";
 
     private final ApplicantRepository applicantRepository;
     private final ApplicantAgreementRepository applicantAgreementRepository;
@@ -57,6 +62,12 @@ public class ApplicantAuthService {
                     throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
                 });
 
+        if (isTestEmail(email)) {
+            emailVerificationRepository.deleteCode(email);
+            emailVerificationRepository.deleteAttemptCount(email);
+            return;
+        }
+
         String code = codeGenerator.generateCode();
 
         emailVerificationRepository.deleteAttemptCount(email);
@@ -72,6 +83,16 @@ public class ApplicantAuthService {
 
     public ApplicantEmailVerifyResponseDTO verifyEmailCode(ApplicantEmailVerifyRequestDTO request) {
         String email = request.email();
+
+        if (isTestEmail(email)) {
+            if (!TEST_EMAIL_VERIFICATION_CODE.equals(request.code())) {
+                throw new BusinessException(ErrorCode.INVALID_VERIFICATION_CODE);
+            }
+
+            emailVerificationRepository.deleteCode(email);
+            emailVerificationRepository.deleteAttemptCount(email);
+            return issueVerificationToken(email);
+        }
 
         // 1) 코드 존재 여부만 확인 (소비하지 않음 - 시도 횟수 한도 내에선 재시도 허용)
         String savedCode = emailVerificationRepository.findCodeByEmail(email)
@@ -93,11 +114,25 @@ public class ApplicantAuthService {
         }
 
         // 5) 일치 - 코드/카운터 정리 + verificationToken 발급
-        String verificationToken = UUID.randomUUID().toString();
-        emailVerificationRepository.saveVerifiedToken(verificationToken, email, VERIFICATION_TOKEN_TTL);
         emailVerificationRepository.deleteCode(email);
         emailVerificationRepository.deleteAttemptCount(email);
 
+        return issueVerificationToken(email);
+    }
+
+    private boolean isTestEmail(String email) {
+        int atIndex = email.lastIndexOf("@");
+        if (atIndex < 0 || atIndex == email.length() - 1) {
+            return false;
+        }
+
+        String domain = email.substring(atIndex + 1).toLowerCase(Locale.ROOT);
+        return TEST_EMAIL_DOMAIN.equals(domain);
+    }
+
+    private ApplicantEmailVerifyResponseDTO issueVerificationToken(String email) {
+        String verificationToken = UUID.randomUUID().toString();
+        emailVerificationRepository.saveVerifiedToken(verificationToken, email, VERIFICATION_TOKEN_TTL);
         return new ApplicantEmailVerifyResponseDTO(verificationToken);
     }
 

--- a/src/test/java/com/weiver/domain/auth/service/ApplicantAuthServiceTest.java
+++ b/src/test/java/com/weiver/domain/auth/service/ApplicantAuthServiceTest.java
@@ -130,6 +130,26 @@ public class ApplicantAuthServiceTest {
     }
 
     @Test
+    @DisplayName("테스트 도메인 이메일이면 인증번호 생성/저장/메일 발송 없이 성공한다.")
+    public void sendEmailCode_testBypassEmailSkipsEmailSend() {
+        // given
+        String email = "qa@weiver.test";
+        ApplicantEmailSendRequestDTO request = new ApplicantEmailSendRequestDTO(email);
+
+        when(applicantRepository.findByEmailAndDeletedFalse(email)).thenReturn(Optional.empty());
+
+        // when
+        applicantAuthService.sendEmailCode(request);
+
+        // then
+        verify(emailVerificationRepository).deleteCode(email);
+        verify(emailVerificationRepository).deleteAttemptCount(email);
+        verify(codeGenerator, never()).generateCode();
+        verify(emailVerificationRepository, never()).saveCode(anyString(), anyString(), any(Duration.class));
+        verify(emailVerificationService, never()).sendVerificationCode(anyString(), anyString());
+    }
+
+    @Test
     @DisplayName("메일 발송 실패 시 저장한 코드를 삭제하고 EMAIL_SEND_FAILED 예외 발생")
     public void sendEmailCode_mailSendFails() {
         // given
@@ -172,6 +192,43 @@ public class ApplicantAuthServiceTest {
         verify(emailVerificationRepository).saveVerifiedToken(eq(response.verificationToken()), eq(email), any(Duration.class));
         verify(emailVerificationRepository).deleteCode(email);
         verify(emailVerificationRepository).deleteAttemptCount(email);
+    }
+
+    @Test
+    @DisplayName("테스트 도메인 이메일은 고정 인증번호로 verificationToken을 발급한다.")
+    public void verifyEmailCode_testBypassEmailSuccess() {
+        // given
+        String email = "qa@weiver.test";
+        String code = "000000";
+        ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO(email, code);
+
+        // when
+        ApplicantEmailVerifyResponseDTO response = applicantAuthService.verifyEmailCode(request);
+
+        // then
+        assertThat(response.verificationToken()).isNotBlank();
+        verify(emailVerificationRepository).deleteCode(email);
+        verify(emailVerificationRepository).deleteAttemptCount(email);
+        verify(emailVerificationRepository).saveVerifiedToken(eq(response.verificationToken()), eq(email), any(Duration.class));
+        verify(emailVerificationRepository, never()).findCodeByEmail(anyString());
+        verify(emailVerificationRepository, never()).incrementAttemptCount(anyString(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("테스트 도메인 이메일도 고정 인증번호가 틀리면 INVALID_VERIFICATION_CODE 예외")
+    public void verifyEmailCode_testBypassEmailInvalidCode() {
+        // given
+        String email = "qa@weiver.test";
+        ApplicantEmailVerifyRequestDTO request = new ApplicantEmailVerifyRequestDTO(email, "111111");
+
+        // when & then
+        assertThatThrownBy(() -> applicantAuthService.verifyEmailCode(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_VERIFICATION_CODE.defaultMessage);
+
+        verify(emailVerificationRepository, never()).findCodeByEmail(anyString());
+        verify(emailVerificationRepository, never()).incrementAttemptCount(anyString(), any(Duration.class));
+        verify(emailVerificationRepository, never()).saveVerifiedToken(anyString(), anyString(), any(Duration.class));
     }
 
     @Test


### PR DESCRIPTION
## 📝 PR 설명
프론트엔드 개발 및 QA 테스트 편의를 위해 `@weiver.test` 도메인 이메일에 한해 실제 이메일 발송 없이 고정 인증번호로 이메일 인증을 통과할 수 있도록 구현했습니다.

## 📝 Summary
- `/api/auth/applicants/email/send` 요청 시 인증번호 생성/Redis 저장/메일 발송을 생략하도록 처리
- `/api/auth/applicants/email/verify` 요청 시 고정 인증번호 `000000`으로 verificationToken 발급
- 기존 일반 이메일 인증 흐름은 유지
- 테스트용 우회 로직 삭제 범위를 주석으로 명시
- 테스트 도메인 인증번호 전송/검증 성공 및 실패 케이스 단위 테스트 추가

## 🙏 Question & PR point
- 테스트용 임시 우회 로직입니다.
- 배포 이후 해당 우회가 필요 없어지면 `TEST_EMAIL_*` 상수, `isTestEmail()`, send/verify 분기, 관련 테스트를 함께 삭제하면 됩니다.

## 📬 Postman

## 📣 Related Issue
- close #99 

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test email verification bypass flow for development and QA environments.

* **Tests**
  * Added test coverage for email verification bypass functionality, including bypass skipping and invalid code scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->