### PR TITLE
[Feature] RabbitMQ 기반 AI 분석 및 매칭 이벤트 플로우 구현

### DIFF
--- a/src/main/java/com/weiver/analysis/domain/CultureReport.java
+++ b/src/main/java/com/weiver/analysis/domain/CultureReport.java
@@ -16,7 +16,13 @@ import java.util.List;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
-@Table(name = "culture_reports")
+@Table(
+        name = "culture_reports",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_culture_reports_applicant_id",
+                columnNames = "applicant_id"
+        )
+)
 public class CultureReport extends BaseTimeEntity {
 
     @Id
@@ -39,6 +45,11 @@ public class CultureReport extends BaseTimeEntity {
 
     public void assignApplicant(Applicant applicant) {
         this.applicant = applicant;
+    }
+
+    public void updateAnalysis(CulturefitStyle culturefitStyle, List<String> culturefitTag) {
+        this.culturefitStyles = culturefitStyle;
+        this.culturefitTag = culturefitTag;
     }
 
 }

--- a/src/main/java/com/weiver/analysis/domain/JdAnalysisResult.java
+++ b/src/main/java/com/weiver/analysis/domain/JdAnalysisResult.java
@@ -1,0 +1,51 @@
+package com.weiver.analysis.domain;
+
+import com.weiver.global.common.BaseTimeEntity;
+import com.weiver.jobposting.domain.JobPosting;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+        name = "jd_analysis_results",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_jd_analysis_results_jd_id",
+                columnNames = "jd_id"
+        )
+)
+public class JdAnalysisResult extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "jd_analysis_result_id")
+    private Long jdAnalysisResultId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "jd_id", nullable = false, unique = true)
+    @ToString.Exclude
+    private JobPosting jobPosting;
+
+    @Column(name = "company_id", nullable = false)
+    private Long companyId;
+
+    @Column(name = "original_text", columnDefinition = "TEXT")
+    private String originalText;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "embedding", columnDefinition = "jsonb")
+    private List<Double> embedding;
+
+    public void updateAnalysis(Long companyId, String originalText, List<Double> embedding) {
+        this.companyId = companyId;
+        this.originalText = originalText;
+        this.embedding = embedding;
+    }
+}

--- a/src/main/java/com/weiver/analysis/domain/TechnicalSkillReport.java
+++ b/src/main/java/com/weiver/analysis/domain/TechnicalSkillReport.java
@@ -15,7 +15,13 @@ import java.util.List;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
-@Table(name = "technical_skill_reports")
+@Table(
+        name = "technical_skill_reports",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_technical_skill_reports_applicant_id",
+                columnNames = "applicant_id"
+        )
+)
 public class TechnicalSkillReport extends BaseTimeEntity {
 
     /**
@@ -34,6 +40,12 @@ public class TechnicalSkillReport extends BaseTimeEntity {
     @Column(name = "application_provider_tags", columnDefinition = "jsonb")
     private List<String> applicationProviderTags; // 유저 제공 스킬 태그
 
+    @Column(name = "job") // 대분류(ex. DEVELOPER)
+    private String job;
+
+    @Column(name = "role") // 소분류(ex. BACKEND)
+    private String role;
+
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "applicant_id", nullable = false, unique = true)
     @ToString.Exclude
@@ -41,6 +53,12 @@ public class TechnicalSkillReport extends BaseTimeEntity {
 
     public void assignApplicant(Applicant applicant) {
         this.applicant = applicant;
+    }
+
+    public void updateAnalysis(List<String> skillTags, String job, String role) {
+        this.skillTags = skillTags;
+        this.job = job;
+        this.role = role;
     }
 
 }

--- a/src/main/java/com/weiver/analysis/event/ApplicantAnalysisEventService.java
+++ b/src/main/java/com/weiver/analysis/event/ApplicantAnalysisEventService.java
@@ -1,0 +1,29 @@
+package com.weiver.analysis.event;
+
+import com.weiver.analysis.event.dto.ApplicantAnalysisRequestedData;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.publisher.DomainEventPublisher;
+import com.weiver.global.event.util.EventIds;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicantAnalysisEventService {
+
+    private final DomainEventPublisher domainEventPublisher;
+
+    /**
+     * 프로필 동기화가 끝난 지원자의 분석 요청 이벤트를 발행한다.
+     */
+    public void publishApplicantAnalysisRequested(Long applicantId) {
+        EventEnvelope<ApplicantAnalysisRequestedData> envelope = EventEnvelope.request(
+                EventType.APPLICANT_ANALYSIS_REQUESTED,
+                new ApplicantAnalysisRequestedData(applicantId),
+                EventIds.newEventId()
+        );
+
+        domainEventPublisher.publish(envelope);
+    }
+}

--- a/src/main/java/com/weiver/analysis/event/dto/ApplicantAnalysisCompletedData.java
+++ b/src/main/java/com/weiver/analysis/event/dto/ApplicantAnalysisCompletedData.java
@@ -1,0 +1,19 @@
+package com.weiver.analysis.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record ApplicantAnalysisCompletedData(
+        @JsonProperty("applicant_id")
+        Long applicantId,
+        @JsonProperty("skill_tags")
+        List<String> skillTags,
+        String job,
+        String role,
+        @JsonProperty("culturefit_style")
+        String culturefitStyle,
+        @JsonProperty("culturefit_tags")
+        List<String> culturefitTags
+) {
+}

--- a/src/main/java/com/weiver/analysis/event/dto/ApplicantAnalysisRequestedData.java
+++ b/src/main/java/com/weiver/analysis/event/dto/ApplicantAnalysisRequestedData.java
@@ -1,0 +1,9 @@
+package com.weiver.analysis.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ApplicantAnalysisRequestedData(
+        @JsonProperty("applicant_id")
+        Long applicantId
+) {
+}

--- a/src/main/java/com/weiver/analysis/event/handler/ApplicantAnalysisCompletedHandler.java
+++ b/src/main/java/com/weiver/analysis/event/handler/ApplicantAnalysisCompletedHandler.java
@@ -46,12 +46,19 @@ public class ApplicantAnalysisCompletedHandler implements DomainEventHandler {
                 envelope.data(),
                 ApplicantAnalysisCompletedData.class
         );
+        validate(data);
 
         Applicant applicant = applicantRepository.findById(data.applicantId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
 
         upsertTechnicalSkillReport(applicant, data);
         upsertCultureReportIfPresent(applicant, data);
+    }
+
+    private void validate(ApplicantAnalysisCompletedData data) {
+        if (data.applicantId() == null) {
+            throw new NonRetryableEventException("applicant_id is required");
+        }
     }
 
     /**

--- a/src/main/java/com/weiver/analysis/event/handler/ApplicantAnalysisCompletedHandler.java
+++ b/src/main/java/com/weiver/analysis/event/handler/ApplicantAnalysisCompletedHandler.java
@@ -1,0 +1,109 @@
+package com.weiver.analysis.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.analysis.domain.CultureReport;
+import com.weiver.analysis.domain.TechnicalSkillReport;
+import com.weiver.analysis.event.dto.ApplicantAnalysisCompletedData;
+import com.weiver.analysis.repository.CultureReportRepository;
+import com.weiver.analysis.repository.TechnicalSkillReportRepository;
+import com.weiver.analysis.type.CulturefitStyle;
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.global.event.consumer.DomainEventHandler;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.NonRetryableEventException;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ApplicantAnalysisCompletedHandler implements DomainEventHandler {
+
+    private final ObjectMapper objectMapper;
+    private final ApplicantRepository applicantRepository;
+    private final TechnicalSkillReportRepository technicalSkillReportRepository;
+    private final CultureReportRepository cultureReportRepository;
+
+    @Override
+    public EventType support() {
+        return EventType.APPLICANT_ANALYSIS_COMPLETED;
+    }
+
+    @Override
+    @Transactional
+    public void handle(EventEnvelope<JsonNode> envelope) {
+        // AI 분석 결과를 지원자 기준으로 멱등 저장한다.
+        ApplicantAnalysisCompletedData data = objectMapper.convertValue(
+                envelope.data(),
+                ApplicantAnalysisCompletedData.class
+        );
+
+        Applicant applicant = applicantRepository.findById(data.applicantId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        upsertTechnicalSkillReport(applicant, data);
+        upsertCultureReportIfPresent(applicant, data);
+    }
+
+    /**
+     * 기술 태그와 직무/역할 분석 결과를 있으면 갱신하고 없으면 새로 저장한다.
+     */
+    private void upsertTechnicalSkillReport(Applicant applicant, ApplicantAnalysisCompletedData data) {
+        technicalSkillReportRepository.findByApplicant_ApplicantId(applicant.getApplicantId())
+                .ifPresentOrElse(
+                        report -> report.updateAnalysis(safeList(data.skillTags()), data.job(), data.role()),
+                        () -> technicalSkillReportRepository.save(TechnicalSkillReport.builder()
+                                .applicant(applicant)
+                                .skillTags(safeList(data.skillTags()))
+                                .job(data.job())
+                                .role(data.role())
+                                .build())
+                );
+    }
+
+    /**
+     * 컬처핏 결과가 payload에 포함된 경우에만 컬처 리포트를 upsert한다.
+     */
+    private void upsertCultureReportIfPresent(Applicant applicant, ApplicantAnalysisCompletedData data) {
+        CulturefitStyle culturefitStyle = parseCulturefitStyle(data.culturefitStyle());
+        List<String> culturefitTags = safeList(data.culturefitTags());
+
+        if (culturefitStyle == null && culturefitTags.isEmpty()) {
+            return;
+        }
+
+        cultureReportRepository.findByApplicant_ApplicantId(applicant.getApplicantId())
+                .ifPresentOrElse(
+                        report -> report.updateAnalysis(culturefitStyle, culturefitTags),
+                        () -> cultureReportRepository.save(CultureReport.builder()
+                                .applicant(applicant)
+                                .culturefitStyles(culturefitStyle)
+                                .culturefitTag(culturefitTags)
+                                .build())
+                );
+    }
+
+    private CulturefitStyle parseCulturefitStyle(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+
+        return Arrays.stream(CulturefitStyle.values())
+                .filter(style -> style.name().equals(value) || style.getDescription().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new NonRetryableEventException("Unsupported culturefit_style: " + value));
+    }
+
+    private List<String> safeList(List<String> values) {
+        return values != null ? values : List.of();
+    }
+}

--- a/src/main/java/com/weiver/analysis/repository/JdAnalysisResultRepository.java
+++ b/src/main/java/com/weiver/analysis/repository/JdAnalysisResultRepository.java
@@ -1,0 +1,12 @@
+package com.weiver.analysis.repository;
+
+import com.weiver.analysis.domain.JdAnalysisResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface JdAnalysisResultRepository extends JpaRepository<JdAnalysisResult, Long> {
+    Optional<JdAnalysisResult> findByJobPosting_JdId(Long jdId);
+}

--- a/src/main/java/com/weiver/applicant/event/ApplicantProfileEventService.java
+++ b/src/main/java/com/weiver/applicant/event/ApplicantProfileEventService.java
@@ -1,0 +1,110 @@
+package com.weiver.applicant.event;
+
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.domain.Education;
+import com.weiver.applicant.domain.WorkExperience;
+import com.weiver.applicant.event.dto.ApplicantProfileChangedData;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.applicant.repository.CertificateRepository;
+import com.weiver.applicant.repository.EducationRepository;
+import com.weiver.applicant.repository.WorkExperienceRepository;
+import com.weiver.essay.repository.EssayAnswerRepository;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.publisher.DomainEventPublisher;
+import com.weiver.global.event.util.EventIds;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ApplicantProfileEventService {
+
+    private final ApplicantRepository applicantRepository;
+    private final EducationRepository educationRepository;
+    private final WorkExperienceRepository workExperienceRepository;
+    private final CertificateRepository certificateRepository;
+    private final EssayAnswerRepository essayAnswerRepository;
+    private final DomainEventPublisher domainEventPublisher;
+
+    /**
+     * 지원자 프로필 전체 스냅샷을 AI 서버로 보내고 동기화 요청 상태로 바꾼다.
+     */
+    public void publishProfileChanged(Long applicantId) {
+        Applicant applicant = applicantRepository.findById(applicantId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        ApplicantProfileChangedData data = toProfileChangedData(applicant);
+        EventEnvelope<ApplicantProfileChangedData> envelope = EventEnvelope.request(
+                EventType.APPLICANT_PROFILE_CHANGED,
+                data,
+                EventIds.newEventId()
+        );
+
+        domainEventPublisher.publish(envelope);
+        applicant.markProfileSyncRequested();
+    }
+
+    /**
+     * 지원자 기본 정보, 학력, 경력, 자격증, 자기소개서를 이벤트 payload로 조합한다.
+     */
+    private ApplicantProfileChangedData toProfileChangedData(Applicant applicant) {
+        return new ApplicantProfileChangedData(
+                applicant.getApplicantId(),
+                applicant.getName(),
+                educationRepository.findAllByApplicant(applicant).stream()
+                        .map(this::toEducationData)
+                        .toList(),
+                workExperienceRepository.findAllByApplicantOrderByStartDateDesc(applicant).stream()
+                        .map(this::toExperienceData)
+                        .toList(),
+                certificateRepository.findAllByApplicant(applicant).stream()
+                        .map(certificate -> certificate.getCertificateName())
+                        .toList(),
+                essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant).stream()
+                        .map(answer -> new ApplicantProfileChangedData.EssayData(
+                                answer.getAnswerId(),
+                                answer.getEssayQuestion().getQuestion(),
+                                answer.getAnswer()
+                        ))
+                        .toList()
+        );
+    }
+
+    private ApplicantProfileChangedData.EducationData toEducationData(Education education) {
+        return new ApplicantProfileChangedData.EducationData(
+                education.getEducationId(),
+                education.getDegree() != null ? education.getDegree().name() : null,
+                education.getSchoolName(),
+                education.getMajor(),
+                education.getGpa(),
+                format(education.getStartDate()),
+                format(education.getEndDate()),
+                education.getStatus() != null ? education.getStatus().name() : null
+        );
+    }
+
+    private ApplicantProfileChangedData.ExperienceData toExperienceData(WorkExperience experience) {
+        return new ApplicantProfileChangedData.ExperienceData(
+                experience.getExperienceId(),
+                experience.getCompanyName(),
+                experience.getStartDate(),
+                experience.getEndDate(),
+                experience.getEmploymentType() != null ? experience.getEmploymentType().name() : null,
+                experience.getPosition(),
+                experience.getDuties(),
+                experience.isRecognized()
+        );
+    }
+
+    private String format(YearMonth yearMonth) {
+        return yearMonth != null ? yearMonth.toString() : null;
+    }
+}

--- a/src/main/java/com/weiver/applicant/event/ApplicantProfileEventService.java
+++ b/src/main/java/com/weiver/applicant/event/ApplicantProfileEventService.java
@@ -18,6 +18,8 @@ import com.weiver.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.YearMonth;
 import java.util.List;
@@ -48,8 +50,8 @@ public class ApplicantProfileEventService {
                 EventIds.newEventId()
         );
 
-        domainEventPublisher.publish(envelope);
         applicant.markProfileSyncRequested();
+        publishAfterCommit(envelope);
     }
 
     /**
@@ -106,5 +108,20 @@ public class ApplicantProfileEventService {
 
     private String format(YearMonth yearMonth) {
         return yearMonth != null ? yearMonth.toString() : null;
+    }
+
+    private void publishAfterCommit(EventEnvelope<?> envelope) {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()
+                || !TransactionSynchronizationManager.isSynchronizationActive()) {
+            domainEventPublisher.publish(envelope);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                domainEventPublisher.publish(envelope);
+            }
+        });
     }
 }

--- a/src/main/java/com/weiver/applicant/event/dto/ApplicantProfileChangedData.java
+++ b/src/main/java/com/weiver/applicant/event/dto/ApplicantProfileChangedData.java
@@ -1,0 +1,49 @@
+package com.weiver.applicant.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public record ApplicantProfileChangedData(
+        @JsonProperty("applicant_id")
+        Long applicantId,
+        @JsonProperty("applicant_name")
+        String applicantName,
+        List<EducationData> educations,
+        List<ExperienceData> experiences,
+        List<String> certifications,
+        List<EssayData> essay
+) {
+    public record EducationData(
+            Long id,
+            String degree,
+            @JsonProperty("school_name") String schoolName,
+            String major,
+            BigDecimal gpa,
+            @JsonProperty("start_date") String startDate,
+            @JsonProperty("end_date") String endDate,
+            String status
+    ) {
+    }
+
+    public record ExperienceData(
+            Long id,
+            @JsonProperty("company_name") String companyName,
+            @JsonProperty("start_date") LocalDate startDate,
+            @JsonProperty("end_date") LocalDate endDate,
+            @JsonProperty("employment_type") String employmentType,
+            String position,
+            String duties,
+            @JsonProperty("is_recognized") boolean recognized
+    ) {
+    }
+
+    public record EssayData(
+            Long id,
+            String question,
+            String answer
+    ) {
+    }
+}

--- a/src/main/java/com/weiver/applicant/event/dto/ApplicantProfileSyncCompletedData.java
+++ b/src/main/java/com/weiver/applicant/event/dto/ApplicantProfileSyncCompletedData.java
@@ -1,0 +1,10 @@
+package com.weiver.applicant.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ApplicantProfileSyncCompletedData(
+        @JsonProperty("applicant_id")
+        Long applicantId,
+        Boolean synced
+) {
+}

--- a/src/main/java/com/weiver/applicant/event/handler/ApplicantProfileSyncCompletedHandler.java
+++ b/src/main/java/com/weiver/applicant/event/handler/ApplicantProfileSyncCompletedHandler.java
@@ -1,0 +1,55 @@
+package com.weiver.applicant.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.analysis.event.ApplicantAnalysisEventService;
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.event.dto.ApplicantProfileSyncCompletedData;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.applicant.type.ProfileSyncStatus;
+import com.weiver.global.event.consumer.DomainEventHandler;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ApplicantProfileSyncCompletedHandler implements DomainEventHandler {
+
+    private final ObjectMapper objectMapper;
+    private final ApplicantRepository applicantRepository;
+    private final ApplicantAnalysisEventService applicantAnalysisEventService;
+
+    @Override
+    public EventType support() {
+        return EventType.APPLICANT_PROFILE_SYNC_COMPLETED;
+    }
+
+    @Override
+    @Transactional
+    public void handle(EventEnvelope<JsonNode> envelope) {
+        // AI 서버의 프로필 upsert 결과를 반영하고, 성공 시 다음 분석 요청을 이어서 발행한다.
+        ApplicantProfileSyncCompletedData data = objectMapper.convertValue(
+                envelope.data(),
+                ApplicantProfileSyncCompletedData.class
+        );
+
+        Applicant applicant = applicantRepository.findById(data.applicantId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        if (Boolean.FALSE.equals(data.synced())) {
+            applicant.markProfileSyncFailed();
+            return;
+        }
+        if (applicant.getProfileSyncStatus() == ProfileSyncStatus.COMPLETED) {
+            return;
+        }
+
+        applicant.markProfileSyncCompleted(envelope.occurredAt());
+        applicantAnalysisEventService.publishApplicantAnalysisRequested(applicant.getApplicantId());
+    }
+}

--- a/src/main/java/com/weiver/applicant/event/handler/ApplicantProfileSyncCompletedHandler.java
+++ b/src/main/java/com/weiver/applicant/event/handler/ApplicantProfileSyncCompletedHandler.java
@@ -10,6 +10,7 @@ import com.weiver.applicant.type.ProfileSyncStatus;
 import com.weiver.global.event.consumer.DomainEventHandler;
 import com.weiver.global.event.dto.EventEnvelope;
 import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.NonRetryableEventException;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -37,19 +38,29 @@ public class ApplicantProfileSyncCompletedHandler implements DomainEventHandler 
                 envelope.data(),
                 ApplicantProfileSyncCompletedData.class
         );
+        validate(data);
 
         Applicant applicant = applicantRepository.findById(data.applicantId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
 
-        if (Boolean.FALSE.equals(data.synced())) {
-            applicant.markProfileSyncFailed();
+        if (applicant.getProfileSyncStatus() == ProfileSyncStatus.COMPLETED) {
             return;
         }
-        if (applicant.getProfileSyncStatus() == ProfileSyncStatus.COMPLETED) {
+        if (Boolean.FALSE.equals(data.synced())) {
+            applicant.markProfileSyncFailed();
             return;
         }
 
         applicant.markProfileSyncCompleted(envelope.occurredAt());
         applicantAnalysisEventService.publishApplicantAnalysisRequested(applicant.getApplicantId());
+    }
+
+    private void validate(ApplicantProfileSyncCompletedData data) {
+        if (data.applicantId() == null) {
+            throw new NonRetryableEventException("applicant_id is required");
+        }
+        if (data.synced() == null) {
+            throw new NonRetryableEventException("synced is required");
+        }
     }
 }

--- a/src/main/java/com/weiver/applicant/service/ApplicantService.java
+++ b/src/main/java/com/weiver/applicant/service/ApplicantService.java
@@ -9,8 +9,6 @@ import com.weiver.essay.repository.EssayAnswerRepository;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import com.weiver.global.s3.service.S3Service;
-import com.weiver.matching.dto.response.PortfolioDetailDTO;
-import com.weiver.matching.dto.response.ProfileDetailDTO;
 import com.weiver.portfolio.repository.PortfolioRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/weiver/applicant/service/ApplicantService.java
+++ b/src/main/java/com/weiver/applicant/service/ApplicantService.java
@@ -3,6 +3,7 @@ package com.weiver.applicant.service;
 import com.weiver.applicant.domain.*;
 import com.weiver.applicant.dto.request.put.*;
 import com.weiver.applicant.dto.response.*;
+import com.weiver.applicant.event.ApplicantProfileEventService;
 import com.weiver.applicant.repository.*;
 import com.weiver.essay.repository.EssayAnswerRepository;
 import com.weiver.global.exception.BusinessException;
@@ -34,6 +35,7 @@ public class ApplicantService {
     private final PortfolioRepository portfolioRepository;
     private final WorkExperienceService workExperienceService;
     private final S3Service s3Service;
+    private final ApplicantProfileEventService applicantProfileEventService;
 
     public void updateApplicantInfo(String publicId, ApplicantInfoRequestDTO requestDTO, MultipartFile profileImage) {
 
@@ -51,6 +53,7 @@ public class ApplicantService {
         }
 
         applicant.updateInfo(requestDTO, photoUrl);
+        applicantProfileEventService.publishProfileChanged(applicant.getApplicantId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/weiver/applicant/service/CertificateService.java
+++ b/src/main/java/com/weiver/applicant/service/CertificateService.java
@@ -5,6 +5,7 @@ import com.weiver.applicant.domain.Certificate;
 import com.weiver.applicant.dto.request.post.CertificateRequestDTO;
 import com.weiver.applicant.dto.request.put.CertificateUpdateDetailDTO;
 import com.weiver.applicant.dto.request.put.CertificateUpdateRequestDTO;
+import com.weiver.applicant.event.ApplicantProfileEventService;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.applicant.repository.CertificateRepository;
 import com.weiver.global.exception.BusinessException;
@@ -26,12 +27,14 @@ public class CertificateService {
 
     private final CertificateRepository certificateRepository;
     private final ApplicantRepository applicantRepository;
+    private final ApplicantProfileEventService applicantProfileEventService;
 
     public void saveCertificateInfo(String publicId, CertificateRequestDTO requestDTO) {
         Applicant applicant = getApplicant(publicId);
         List<Certificate> certificateList = requestDTO.toEntityList(applicant);
 
         certificateRepository.saveAll(certificateList);
+        applicantProfileEventService.publishProfileChanged(applicant.getApplicantId());
     }
 
 
@@ -71,6 +74,8 @@ public class CertificateService {
         if (!toSave.isEmpty()) {
             certificateRepository.saveAll(toSave);
         }
+
+        applicantProfileEventService.publishProfileChanged(applicant.getApplicantId());
     }
 
 

--- a/src/main/java/com/weiver/applicant/service/EducationService.java
+++ b/src/main/java/com/weiver/applicant/service/EducationService.java
@@ -5,6 +5,7 @@ import com.weiver.applicant.domain.Education;
 import com.weiver.applicant.dto.request.post.EducationRequestDTO;
 import com.weiver.applicant.dto.request.put.EducationUpdateDetailDTO;
 import com.weiver.applicant.dto.request.put.EducationUpdateRequestDTO;
+import com.weiver.applicant.event.ApplicantProfileEventService;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.applicant.repository.EducationRepository;
 import com.weiver.global.exception.BusinessException;
@@ -26,6 +27,7 @@ public class EducationService {
 
     private final EducationRepository educationRepository;
     private final ApplicantRepository applicantRepository;
+    private final ApplicantProfileEventService applicantProfileEventService;
 
     public void saveEducationInfo(String publicId, EducationRequestDTO requestDTO) {
 
@@ -34,6 +36,7 @@ public class EducationService {
         List<Education> educationList = requestDTO.toEntityList(applicant);
 
         educationRepository.saveAll(educationList);
+        applicantProfileEventService.publishProfileChanged(applicant.getApplicantId());
     }
 
 
@@ -78,6 +81,8 @@ public class EducationService {
         if (!toSave.isEmpty()) {
             educationRepository.saveAll(toSave);
         }
+
+        applicantProfileEventService.publishProfileChanged(applicant.getApplicantId());
     }
 
 

--- a/src/main/java/com/weiver/applicant/service/WorkExperienceService.java
+++ b/src/main/java/com/weiver/applicant/service/WorkExperienceService.java
@@ -5,6 +5,7 @@ import com.weiver.applicant.domain.WorkExperience;
 import com.weiver.applicant.dto.request.post.WorkExperienceRequestDTO;
 import com.weiver.applicant.dto.request.put.WorkExperienceUpdateDetailDTO;
 import com.weiver.applicant.dto.request.put.WorkExperienceUpdateRequestDTO;
+import com.weiver.applicant.event.ApplicantProfileEventService;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.applicant.repository.WorkExperienceRepository;
 import com.weiver.global.exception.BusinessException;
@@ -27,6 +28,7 @@ public class WorkExperienceService {
 
     private final WorkExperienceRepository workExperienceRepository;
     private final ApplicantRepository applicantRepository;
+    private final ApplicantProfileEventService applicantProfileEventService;
 
 
     public void saveWorkExperienceInfo(String publicId, WorkExperienceRequestDTO requestDTO) {
@@ -35,6 +37,7 @@ public class WorkExperienceService {
         List<WorkExperience> experienceList = requestDTO.toEntityList(applicant);
 
         workExperienceRepository.saveAll(experienceList);
+        applicantProfileEventService.publishProfileChanged(applicant.getApplicantId());
     }
 
     public void updateWorkExperienceInfo(String publicId, WorkExperienceUpdateRequestDTO requestDTO) {
@@ -73,6 +76,8 @@ public class WorkExperienceService {
         if (!toSave.isEmpty()) {
             workExperienceRepository.saveAll(toSave);
         }
+
+        applicantProfileEventService.publishProfileChanged(applicant.getApplicantId());
     }
 
     /**

--- a/src/main/java/com/weiver/essay/service/EssayAnswerService.java
+++ b/src/main/java/com/weiver/essay/service/EssayAnswerService.java
@@ -1,6 +1,7 @@
 package com.weiver.essay.service;
 
 import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.event.ApplicantProfileEventService;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.essay.domain.EssayAnswer;
 import com.weiver.essay.domain.EssayQuestion;
@@ -33,6 +34,7 @@ public class EssayAnswerService {
     private final EssayAnswerRepository essayAnswerRepository;
     private final EssayQuestionRepository essayQuestionRepository;
     private final ApplicantRepository applicantRepository;
+    private final ApplicantProfileEventService applicantProfileEventService;
 
 
     public void saveEssayAnswer(EssayAnswerRequestDTO requestDTO, String publicId) {
@@ -49,6 +51,7 @@ public class EssayAnswerService {
                 .toList();
 
         essayAnswerRepository.saveAll(essayAnswers);
+        applicantProfileEventService.publishProfileChanged(applicant.getApplicantId());
     }
 
     public void updateEssayAnswers(EssayAnswerUpdateRequestDTO requestDTO, String publicId) {
@@ -71,6 +74,7 @@ public class EssayAnswerService {
         }
 
         requestDTO.answers().forEach(answerItem -> updateAnswer(answerItem, existingAnswerMap.get(answerItem.answerId())));
+        applicantProfileEventService.publishProfileChanged(applicant.getApplicantId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/weiver/jobposting/domain/JobPosting.java
+++ b/src/main/java/com/weiver/jobposting/domain/JobPosting.java
@@ -113,34 +113,21 @@ public class JobPosting extends BaseTimeEntity {
     }
 
     public void markJdAnalysisRequested() {
-        if (this.jdAnalysisStatus == JdAnalysisStatus.REQUESTED) {
-            return;
-        }
-        if (this.jdAnalysisStatus == JdAnalysisStatus.COMPLETED) {
-            throw new IllegalStateException("Completed JD analysis cannot be requested again.");
-        }
         this.jdAnalysisStatus = JdAnalysisStatus.REQUESTED;
         this.jdAnalysisRequestedAt = OffsetDateTime.now();
+        this.jdAnalyzedAt = null;
     }
 
     public void markJdAnalysisCompleted() {
-        if (this.jdAnalysisStatus == JdAnalysisStatus.COMPLETED) {
-            return;
-        }
-        if (this.jdAnalysisStatus != JdAnalysisStatus.REQUESTED) {
-            throw new IllegalStateException("JD analysis can be completed only after it has been requested.");
-        }
+        markJdAnalysisCompleted(OffsetDateTime.now());
+    }
+
+    public void markJdAnalysisCompleted(OffsetDateTime analyzedAt) {
         this.jdAnalysisStatus = JdAnalysisStatus.COMPLETED;
-        this.jdAnalyzedAt = OffsetDateTime.now();
+        this.jdAnalyzedAt = analyzedAt;
     }
 
     public void markJdAnalysisFailed() {
-        if (this.jdAnalysisStatus == JdAnalysisStatus.FAILED) {
-            return;
-        }
-        if (this.jdAnalysisStatus == JdAnalysisStatus.COMPLETED) {
-            throw new IllegalStateException("Completed JD analysis cannot be marked as failed.");
-        }
         this.jdAnalysisStatus = JdAnalysisStatus.FAILED;
     }
 }

--- a/src/main/java/com/weiver/jobposting/domain/JobPosting.java
+++ b/src/main/java/com/weiver/jobposting/domain/JobPosting.java
@@ -13,6 +13,7 @@ import org.hibernate.type.SqlTypes;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -124,7 +125,7 @@ public class JobPosting extends BaseTimeEntity {
 
     public void markJdAnalysisCompleted(OffsetDateTime analyzedAt) {
         this.jdAnalysisStatus = JdAnalysisStatus.COMPLETED;
-        this.jdAnalyzedAt = analyzedAt;
+        this.jdAnalyzedAt = Objects.requireNonNull(analyzedAt, "analyzedAt must not be null");
     }
 
     public void markJdAnalysisFailed() {

--- a/src/main/java/com/weiver/jobposting/dto/request/JobPostingRequestDTO.java
+++ b/src/main/java/com/weiver/jobposting/dto/request/JobPostingRequestDTO.java
@@ -58,6 +58,7 @@ public record JobPostingRequestDTO(
                 .title(this.title)
                 .status(status)
                 .jobCategory(this.jobCategory)
+                .detailedJob(this.detailedJob)
                 .deadline(this.deadline)
                 .jobDescription(this.jobDescription)
                 .qualifications(this.qualifications)

--- a/src/main/java/com/weiver/jobposting/event/JobPostingEventService.java
+++ b/src/main/java/com/weiver/jobposting/event/JobPostingEventService.java
@@ -1,0 +1,87 @@
+package com.weiver.jobposting.event;
+
+import com.weiver.company.domain.Company;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.publisher.DomainEventPublisher;
+import com.weiver.global.event.util.EventIds;
+import com.weiver.jobposting.domain.JobPosting;
+import com.weiver.jobposting.event.dto.JdAnalysisRequestedData;
+import com.weiver.jobposting.type.JobPostingStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class JobPostingEventService {
+
+    private final DomainEventPublisher domainEventPublisher;
+
+    /**
+     * ACTIVE 공고만 JD 분석 요청 이벤트로 발행하고 요청 상태를 기록한다.
+     */
+    public void publishJdAnalysisRequested(JobPosting jobPosting) {
+        if (jobPosting.getStatus() != JobPostingStatus.ACTIVE) {
+            return;
+        }
+
+        EventEnvelope<JdAnalysisRequestedData> envelope = EventEnvelope.request(
+                EventType.JD_ANALYSIS_REQUESTED,
+                toJdAnalysisRequestedData(jobPosting),
+                EventIds.newEventId()
+        );
+
+        domainEventPublisher.publish(envelope);
+        jobPosting.markJdAnalysisRequested();
+    }
+
+    /**
+     * 공고 내용과 회사 컬처/업무 방식을 AI 서버가 쓰는 JD 분석 payload로 변환한다.
+     */
+    private JdAnalysisRequestedData toJdAnalysisRequestedData(JobPosting jobPosting) {
+        Company company = jobPosting.getCompany();
+
+        return new JdAnalysisRequestedData(
+                jobPosting.getJdId(),
+                company.getCompanyId(),
+                jobPosting.getTitle(),
+                jobPosting.getJobCategory(),
+                jobPosting.getDetailedJob(),
+                jobPosting.getJobDescription(),
+                jobPosting.getRequirements(),
+                jobPosting.getQualifications(),
+                jobPosting.getPreferredQualifications(),
+                safeList(jobPosting.getRequiredTech()),
+                companyCulture(company),
+                new JdAnalysisRequestedData.WorkStyleData(
+                        company.getWorkPace(),
+                        company.getDecisionMaking(),
+                        company.getRoleDefinition(),
+                        company.getOperationStyle()
+                )
+        );
+    }
+
+    private List<String> safeList(List<String> values) {
+        return values != null ? values : List.of();
+    }
+
+    /**
+     * 회사 문화 설명과 방향성 설명을 하나의 분석용 텍스트로 합친다.
+     */
+    private String companyCulture(Company company) {
+        return Stream.of(company.getCultureDescription(), company.getDirectionDescription())
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .filter(Objects::nonNull)
+                .reduce((left, right) -> left + "\n" + right)
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/weiver/jobposting/event/dto/JdAnalysisCompletedData.java
+++ b/src/main/java/com/weiver/jobposting/event/dto/JdAnalysisCompletedData.java
@@ -1,0 +1,16 @@
+package com.weiver.jobposting.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record JdAnalysisCompletedData(
+        @JsonProperty("jd_id")
+        Long jdId,
+        @JsonProperty("company_id")
+        Long companyId,
+        @JsonProperty("original_text")
+        String originalText,
+        List<Double> embedding
+) {
+}

--- a/src/main/java/com/weiver/jobposting/event/dto/JdAnalysisRequestedData.java
+++ b/src/main/java/com/weiver/jobposting/event/dto/JdAnalysisRequestedData.java
@@ -1,0 +1,45 @@
+package com.weiver.jobposting.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.weiver.company.type.DecisionMaking;
+import com.weiver.company.type.OperationStyle;
+import com.weiver.company.type.RoleDefinition;
+import com.weiver.company.type.WorkPace;
+
+import java.util.List;
+
+public record JdAnalysisRequestedData(
+        @JsonProperty("jd_id")
+        Long jdId,
+        @JsonProperty("company_id")
+        Long companyId,
+        String title,
+        @JsonProperty("job_category")
+        String jobCategory,
+        @JsonProperty("detailed_job")
+        String detailedJob,
+        @JsonProperty("job_description")
+        String jobDescription,
+        String requirements,
+        String qualifications,
+        @JsonProperty("preferred_qualifications")
+        String preferredQualifications,
+        @JsonProperty("required_skills")
+        List<String> requiredSkills,
+        @JsonProperty("company_culture")
+        String companyCulture,
+        @JsonProperty("work_style")
+        WorkStyleData workStyle
+) {
+    public record WorkStyleData(
+            @JsonProperty("progress_speed") // 업무 진행 속도
+            WorkPace progressSpeed,
+            @JsonProperty("decision_maker") // 의사결정 주체
+            DecisionMaking decisionMaker,
+            @JsonProperty("role_definition") // 역할 정의 방식
+            RoleDefinition roleDefinition,
+            @JsonProperty("operating_system") // 운영 방식
+            OperationStyle operatingSystem
+    ) {
+    }
+}

--- a/src/main/java/com/weiver/jobposting/event/handler/JdAnalysisCompletedHandler.java
+++ b/src/main/java/com/weiver/jobposting/event/handler/JdAnalysisCompletedHandler.java
@@ -7,6 +7,7 @@ import com.weiver.analysis.repository.JdAnalysisResultRepository;
 import com.weiver.global.event.consumer.DomainEventHandler;
 import com.weiver.global.event.dto.EventEnvelope;
 import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.NonRetryableEventException;
 import com.weiver.global.exception.BusinessException;
 import com.weiver.global.exception.ErrorCode;
 import com.weiver.jobposting.domain.JobPosting;
@@ -37,13 +38,12 @@ public class JdAnalysisCompletedHandler implements DomainEventHandler {
                 envelope.data(),
                 JdAnalysisCompletedData.class
         );
+        validate(data);
 
         JobPosting jobPosting = jobPostingRepository.findById(data.jdId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_NOT_FOUND));
 
-        Long companyId = data.companyId() != null
-                ? data.companyId()
-                : jobPosting.getCompany().getCompanyId();
+        Long companyId = jobPosting.getCompany().getCompanyId();
 
         jdAnalysisResultRepository.findByJobPosting_JdId(jobPosting.getJdId())
                 .ifPresentOrElse(
@@ -57,5 +57,11 @@ public class JdAnalysisCompletedHandler implements DomainEventHandler {
                 );
 
         jobPosting.markJdAnalysisCompleted(envelope.occurredAt());
+    }
+
+    private void validate(JdAnalysisCompletedData data) {
+        if (data.jdId() == null) {
+            throw new NonRetryableEventException("jd_id is required");
+        }
     }
 }

--- a/src/main/java/com/weiver/jobposting/event/handler/JdAnalysisCompletedHandler.java
+++ b/src/main/java/com/weiver/jobposting/event/handler/JdAnalysisCompletedHandler.java
@@ -1,0 +1,61 @@
+package com.weiver.jobposting.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.analysis.domain.JdAnalysisResult;
+import com.weiver.analysis.repository.JdAnalysisResultRepository;
+import com.weiver.global.event.consumer.DomainEventHandler;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import com.weiver.jobposting.domain.JobPosting;
+import com.weiver.jobposting.event.dto.JdAnalysisCompletedData;
+import com.weiver.jobposting.repository.JobPostingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class JdAnalysisCompletedHandler implements DomainEventHandler {
+
+    private final ObjectMapper objectMapper;
+    private final JobPostingRepository jobPostingRepository;
+    private final JdAnalysisResultRepository jdAnalysisResultRepository;
+
+    @Override
+    public EventType support() {
+        return EventType.JD_ANALYSIS_COMPLETED;
+    }
+
+    @Override
+    @Transactional
+    public void handle(EventEnvelope<JsonNode> envelope) {
+        // JD 분석 결과를 공고 기준으로 저장하고 분석 완료 상태를 기록한다.
+        JdAnalysisCompletedData data = objectMapper.convertValue(
+                envelope.data(),
+                JdAnalysisCompletedData.class
+        );
+
+        JobPosting jobPosting = jobPostingRepository.findById(data.jdId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_NOT_FOUND));
+
+        Long companyId = data.companyId() != null
+                ? data.companyId()
+                : jobPosting.getCompany().getCompanyId();
+
+        jdAnalysisResultRepository.findByJobPosting_JdId(jobPosting.getJdId())
+                .ifPresentOrElse(
+                        result -> result.updateAnalysis(companyId, data.originalText(), data.embedding()),
+                        () -> jdAnalysisResultRepository.save(JdAnalysisResult.builder()
+                                .jobPosting(jobPosting)
+                                .companyId(companyId)
+                                .originalText(data.originalText())
+                                .embedding(data.embedding())
+                                .build())
+                );
+
+        jobPosting.markJdAnalysisCompleted(envelope.occurredAt());
+    }
+}

--- a/src/main/java/com/weiver/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/weiver/jobposting/service/JobPostingService.java
@@ -51,6 +51,7 @@ public class JobPostingService {
     public void saveJobPosting(Boolean isTemp, String publicId, JobPostingRequestDTO requestDTO,
                                MultipartFile bannerImage){
 
+        boolean temporary = Boolean.TRUE.equals(isTemp);
         String bannerImageUrl = null;
         if (bannerImage != null && !bannerImage.isEmpty()) {
             bannerImageUrl = s3Service.publicUpload(bannerImage, "email-banners");
@@ -60,7 +61,7 @@ public class JobPostingService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.COMPANY_NOT_FOUND));
 
         JobPostingStatus status = JobPostingStatus.ACTIVE;
-        if(isTemp){
+        if(temporary){
             status = JobPostingStatus.DRAFT;
         }
         JobPosting jobPosting = requestDTO.toJobPosting(company, status);
@@ -70,7 +71,7 @@ public class JobPostingService {
         EmailTemplate emailTemplate = requestDTO.toEmailTemplate(savedJobPosting, bannerImageUrl);
         emailTemplateRepository.save(emailTemplate);
 
-        if (!isTemp) {
+        if (!temporary) {
             jobPostingEventService.publishJdAnalysisRequested(savedJobPosting);
         }
     }

--- a/src/main/java/com/weiver/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/weiver/jobposting/service/JobPostingService.java
@@ -12,6 +12,7 @@ import com.weiver.jobposting.dto.request.JobPostingUpdateDTO;
 import com.weiver.jobposting.dto.response.JobPostingPageResponseDTO;
 import com.weiver.jobposting.dto.response.JobPostingResponseDTO;
 import com.weiver.jobposting.dto.response.JobPostingsDetails;
+import com.weiver.jobposting.event.JobPostingEventService;
 import com.weiver.jobposting.repository.EmailTemplateRepository;
 import com.weiver.jobposting.repository.JobPostingRepository;
 import com.weiver.jobposting.type.JobPostingStatus;
@@ -28,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -41,6 +43,7 @@ public class JobPostingService {
     private final JobPostingRepository jobPostingRepository;
     private final CompanyRepository companyRepository;
     private final S3Service s3Service;
+    private final JobPostingEventService jobPostingEventService;
 
     /**
      * 기업 공고 통합 생성 API
@@ -66,6 +69,10 @@ public class JobPostingService {
 
         EmailTemplate emailTemplate = requestDTO.toEmailTemplate(savedJobPosting, bannerImageUrl);
         emailTemplateRepository.save(emailTemplate);
+
+        if (!isTemp) {
+            jobPostingEventService.publishJdAnalysisRequested(savedJobPosting);
+        }
     }
 
     /**
@@ -82,6 +89,8 @@ public class JobPostingService {
             throw new BusinessException(ErrorCode.FORBIDDEN, "공고 수정 권한이 없습니다.");
         }
 
+        boolean shouldRequestJdAnalysis = jobPosting.getStatus() == JobPostingStatus.ACTIVE
+                && isJdAnalysisTargetChanged(jobPosting, updateDTO);
 
         String finalBannerUrl = emailTemplate.getEmailBannerUrl();
 
@@ -101,6 +110,10 @@ public class JobPostingService {
 
         jobPosting.updateJobPosting(updateDTO);
         emailTemplate.updateEmailTemplate(updateDTO, finalBannerUrl);
+
+        if (shouldRequestJdAnalysis) {
+            jobPostingEventService.publishJdAnalysisRequested(jobPosting);
+        }
     }
     
     /**
@@ -168,5 +181,16 @@ public class JobPostingService {
         }
 
         jobPostingRepository.delete(jobPosting);
+    }
+
+    private boolean isJdAnalysisTargetChanged(JobPosting jobPosting, JobPostingUpdateDTO updateDTO) {
+        return !Objects.equals(jobPosting.getTitle(), updateDTO.title())
+                || !Objects.equals(jobPosting.getJobCategory(), updateDTO.jobCategory())
+                || !Objects.equals(jobPosting.getDetailedJob(), updateDTO.detailedJob())
+                || !Objects.equals(jobPosting.getJobDescription(), updateDTO.jobDescription())
+                || !Objects.equals(jobPosting.getRequirements(), updateDTO.requirements())
+                || !Objects.equals(jobPosting.getQualifications(), updateDTO.qualifications())
+                || !Objects.equals(jobPosting.getPreferredQualifications(), updateDTO.preferredQualifications())
+                || !Objects.equals(jobPosting.getRequiredTech(), updateDTO.requiredTechs());
     }
 }

--- a/src/main/java/com/weiver/matching/event/MatchingEventService.java
+++ b/src/main/java/com/weiver/matching/event/MatchingEventService.java
@@ -1,0 +1,69 @@
+package com.weiver.matching.event;
+
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.publisher.DomainEventPublisher;
+import com.weiver.global.event.util.EventIds;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import com.weiver.jobposting.domain.JobPosting;
+import com.weiver.jobposting.repository.JobPostingRepository;
+import com.weiver.jobposting.type.JobPostingStatus;
+import com.weiver.matching.event.dto.MatchingRequestedData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MatchingEventService {
+
+    private final JobPostingRepository jobPostingRepository;
+    private final DomainEventPublisher domainEventPublisher;
+
+    /**
+     * 스케줄러 등 내부 흐름에서 공고 ID로 AI 매칭 요청 이벤트를 발행한다.
+     */
+    public void publishMatchingRequested(Long jdId) {
+        JobPosting jobPosting = jobPostingRepository.findById(jdId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_NOT_FOUND));
+
+        publishMatchingRequested(jobPosting);
+    }
+
+    /**
+     * ACTIVE 공고만 AI 매칭 요청 이벤트로 발행한다.
+     */
+    public void publishMatchingRequested(JobPosting jobPosting) {
+        if (jobPosting.getStatus() != JobPostingStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "활성화된 공고만 매칭을 실행할 수 있습니다.");
+        }
+
+        EventEnvelope<MatchingRequestedData> envelope = EventEnvelope.request(
+                EventType.MATCHING_REQUESTED,
+                toMatchingRequestedData(jobPosting),
+                EventIds.newEventId()
+        );
+
+        domainEventPublisher.publish(envelope);
+    }
+
+    /**
+     * 공고의 기술 스택과 요구사항을 매칭 요청 payload로 변환한다.
+     */
+    private MatchingRequestedData toMatchingRequestedData(JobPosting jobPosting) {
+        return new MatchingRequestedData(
+                jobPosting.getCompany().getCompanyId(),
+                jobPosting.getJdId(),
+                safeList(jobPosting.getRequiredTech()),
+                jobPosting.getRequirements()
+        );
+    }
+
+    private List<String> safeList(List<String> values) {
+        return values != null ? values : List.of();
+    }
+}

--- a/src/main/java/com/weiver/matching/event/dto/MatchingCompletedData.java
+++ b/src/main/java/com/weiver/matching/event/dto/MatchingCompletedData.java
@@ -1,0 +1,24 @@
+package com.weiver.matching.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record MatchingCompletedData(
+        @JsonProperty("jd_id")
+        Long jdId,
+        List<MatchData> matches
+) {
+    public record MatchData(
+            @JsonProperty("applicant_id")
+            Long applicantId,
+            @JsonProperty("skill_score")
+            Float skillScore,
+            @JsonProperty("culture_score")
+            Float cultureScore,
+            @JsonProperty("final_score")
+            Float finalScore,
+            String reason
+    ) {
+    }
+}

--- a/src/main/java/com/weiver/matching/event/dto/MatchingRequestedData.java
+++ b/src/main/java/com/weiver/matching/event/dto/MatchingRequestedData.java
@@ -1,0 +1,16 @@
+package com.weiver.matching.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record MatchingRequestedData(
+        @JsonProperty("company_id")
+        Long companyId,
+        @JsonProperty("jd_id")
+        Long jdId,
+        @JsonProperty("required_skills")
+        List<String> requiredSkills,
+        String requirements
+) {
+}

--- a/src/main/java/com/weiver/matching/event/handler/MatchingCompletedHandler.java
+++ b/src/main/java/com/weiver/matching/event/handler/MatchingCompletedHandler.java
@@ -19,7 +19,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -43,9 +45,7 @@ public class MatchingCompletedHandler implements DomainEventHandler {
                 envelope.data(),
                 MatchingCompletedData.class
         );
-        if (data.matches() == null) {
-            throw new NonRetryableEventException("matches is required");
-        }
+        validate(data);
 
         JobPosting jobPosting = jobPostingRepository.findById(data.jdId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_NOT_FOUND));
@@ -73,5 +73,24 @@ public class MatchingCompletedHandler implements DomainEventHandler {
                 .matchingRate(match.finalScore())
                 .aiSummary(match.reason())
                 .build();
+    }
+
+    private void validate(MatchingCompletedData data) {
+        if (data.jdId() == null) {
+            throw new NonRetryableEventException("jd_id is required");
+        }
+        if (data.matches() == null) {
+            throw new NonRetryableEventException("matches is required");
+        }
+
+        Set<Long> applicantIds = new HashSet<>();
+        for (MatchingCompletedData.MatchData match : data.matches()) {
+            if (match.applicantId() == null) {
+                throw new NonRetryableEventException("matches.applicant_id is required");
+            }
+            if (!applicantIds.add(match.applicantId())) {
+                throw new NonRetryableEventException("Duplicate applicant_id in matches: " + match.applicantId());
+            }
+        }
     }
 }

--- a/src/main/java/com/weiver/matching/event/handler/MatchingCompletedHandler.java
+++ b/src/main/java/com/weiver/matching/event/handler/MatchingCompletedHandler.java
@@ -1,0 +1,77 @@
+package com.weiver.matching.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.global.event.consumer.DomainEventHandler;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.NonRetryableEventException;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import com.weiver.jobposting.domain.JobPosting;
+import com.weiver.jobposting.repository.JobPostingRepository;
+import com.weiver.matching.domain.MatchResult;
+import com.weiver.matching.event.dto.MatchingCompletedData;
+import com.weiver.matching.repository.MatchResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MatchingCompletedHandler implements DomainEventHandler {
+
+    private final ObjectMapper objectMapper;
+    private final JobPostingRepository jobPostingRepository;
+    private final ApplicantRepository applicantRepository;
+    private final MatchResultRepository matchResultRepository;
+
+    @Override
+    public EventType support() {
+        return EventType.MATCHING_COMPLETED;
+    }
+
+    @Override
+    @Transactional
+    public void handle(EventEnvelope<JsonNode> envelope) {
+        // 같은 공고의 기존 매칭 결과를 지우고 AI가 내려준 최신 결과로 교체한다.
+        MatchingCompletedData data = objectMapper.convertValue(
+                envelope.data(),
+                MatchingCompletedData.class
+        );
+        if (data.matches() == null) {
+            throw new NonRetryableEventException("matches is required");
+        }
+
+        JobPosting jobPosting = jobPostingRepository.findById(data.jdId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_NOT_FOUND));
+
+        matchResultRepository.deleteByJobPosting_JdId(jobPosting.getJdId());
+        matchResultRepository.flush();
+
+        List<MatchResult> matchResults = data.matches().stream()
+                .map(match -> toMatchResult(jobPosting, match))
+                .toList();
+
+        matchResultRepository.saveAll(matchResults);
+    }
+
+    private MatchResult toMatchResult(JobPosting jobPosting, MatchingCompletedData.MatchData match) {
+        Applicant applicant = applicantRepository.findById(match.applicantId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        return MatchResult.builder()
+                .jobPosting(jobPosting)
+                .applicant(applicant)
+                .skillScore(match.skillScore())
+                .culturefitScore(match.cultureScore())
+                .finalScore(match.finalScore())
+                .matchingRate(match.finalScore())
+                .aiSummary(match.reason())
+                .build();
+    }
+}

--- a/src/test/java/com/weiver/analysis/event/handler/ApplicantAnalysisCompletedHandlerTest.java
+++ b/src/test/java/com/weiver/analysis/event/handler/ApplicantAnalysisCompletedHandlerTest.java
@@ -1,0 +1,89 @@
+package com.weiver.analysis.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.analysis.domain.CultureReport;
+import com.weiver.analysis.domain.TechnicalSkillReport;
+import com.weiver.analysis.event.dto.ApplicantAnalysisCompletedData;
+import com.weiver.analysis.repository.CultureReportRepository;
+import com.weiver.analysis.repository.TechnicalSkillReportRepository;
+import com.weiver.analysis.type.CulturefitStyle;
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicantAnalysisCompletedHandlerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock private ApplicantRepository applicantRepository;
+    @Mock private TechnicalSkillReportRepository technicalSkillReportRepository;
+    @Mock private CultureReportRepository cultureReportRepository;
+
+    @Test
+    @DisplayName("지원자 분석 완료 이벤트를 수신하면 기술 리포트와 컬처 리포트를 upsert한다")
+    void handle_UpsertsReports() {
+        ApplicantAnalysisCompletedHandler handler = new ApplicantAnalysisCompletedHandler(
+                objectMapper,
+                applicantRepository,
+                technicalSkillReportRepository,
+                cultureReportRepository
+        );
+        Applicant applicant = Applicant.builder().applicantId(1L).build();
+        ApplicantAnalysisCompletedData data = new ApplicantAnalysisCompletedData(
+                1L,
+                List.of("Java", "Spring"),
+                "Backend",
+                "Server Engineer",
+                CulturefitStyle.INCLUSIVE_INNOVATOR.name(),
+                List.of("협업", "포용")
+        );
+
+        given(applicantRepository.findById(1L)).willReturn(Optional.of(applicant));
+        given(technicalSkillReportRepository.findByApplicant_ApplicantId(1L)).willReturn(Optional.empty());
+        given(cultureReportRepository.findByApplicant_ApplicantId(1L)).willReturn(Optional.empty());
+
+        handler.handle(envelope(data));
+
+        ArgumentCaptor<TechnicalSkillReport> technicalCaptor = ArgumentCaptor.forClass(TechnicalSkillReport.class);
+        ArgumentCaptor<CultureReport> cultureCaptor = ArgumentCaptor.forClass(CultureReport.class);
+        verify(technicalSkillReportRepository).save(technicalCaptor.capture());
+        verify(cultureReportRepository).save(cultureCaptor.capture());
+
+        TechnicalSkillReport technicalSkillReport = technicalCaptor.getValue();
+        assertThat(technicalSkillReport.getSkillTags()).containsExactly("Java", "Spring");
+        assertThat(technicalSkillReport.getJob()).isEqualTo("Backend");
+        assertThat(technicalSkillReport.getRole()).isEqualTo("Server Engineer");
+
+        CultureReport cultureReport = cultureCaptor.getValue();
+        assertThat(cultureReport.getCulturefitStyles()).isEqualTo(CulturefitStyle.INCLUSIVE_INNOVATOR);
+        assertThat(cultureReport.getCulturefitTag()).containsExactly("협업", "포용");
+    }
+
+    private EventEnvelope<JsonNode> envelope(ApplicantAnalysisCompletedData data) {
+        return new EventEnvelope<>(
+                "event-1",
+                EventType.APPLICANT_ANALYSIS_COMPLETED,
+                null,
+                OffsetDateTime.now(),
+                EventEnvelope.CURRENT_VERSION,
+                objectMapper.valueToTree(data)
+        );
+    }
+}

--- a/src/test/java/com/weiver/analysis/event/handler/ApplicantAnalysisCompletedHandlerTest.java
+++ b/src/test/java/com/weiver/analysis/event/handler/ApplicantAnalysisCompletedHandlerTest.java
@@ -12,6 +12,7 @@ import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.global.event.dto.EventEnvelope;
 import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.NonRetryableEventException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -74,6 +76,29 @@ class ApplicantAnalysisCompletedHandlerTest {
         CultureReport cultureReport = cultureCaptor.getValue();
         assertThat(cultureReport.getCulturefitStyles()).isEqualTo(CulturefitStyle.INCLUSIVE_INNOVATOR);
         assertThat(cultureReport.getCulturefitTag()).containsExactly("협업", "포용");
+    }
+
+    @Test
+    @DisplayName("지원자 분석 완료 payload에 applicant_id가 없으면 non-retryable 예외가 발생한다")
+    void handle_ThrowsNonRetryable_WhenApplicantIdIsMissing() {
+        ApplicantAnalysisCompletedHandler handler = new ApplicantAnalysisCompletedHandler(
+                objectMapper,
+                applicantRepository,
+                technicalSkillReportRepository,
+                cultureReportRepository
+        );
+        ApplicantAnalysisCompletedData data = new ApplicantAnalysisCompletedData(
+                null,
+                List.of("Java"),
+                "Backend",
+                "Server Engineer",
+                null,
+                null
+        );
+
+        assertThatThrownBy(() -> handler.handle(envelope(data)))
+                .isInstanceOf(NonRetryableEventException.class)
+                .hasMessage("applicant_id is required");
     }
 
     private EventEnvelope<JsonNode> envelope(ApplicantAnalysisCompletedData data) {

--- a/src/test/java/com/weiver/applicant/event/ApplicantProfileEventServiceTest.java
+++ b/src/test/java/com/weiver/applicant/event/ApplicantProfileEventServiceTest.java
@@ -1,0 +1,125 @@
+package com.weiver.applicant.event;
+
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.domain.Certificate;
+import com.weiver.applicant.domain.Education;
+import com.weiver.applicant.domain.WorkExperience;
+import com.weiver.applicant.event.dto.ApplicantProfileChangedData;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.applicant.repository.CertificateRepository;
+import com.weiver.applicant.repository.EducationRepository;
+import com.weiver.applicant.repository.WorkExperienceRepository;
+import com.weiver.applicant.type.Degree;
+import com.weiver.applicant.type.EmploymentType;
+import com.weiver.applicant.type.ProfileSyncStatus;
+import com.weiver.applicant.type.Status;
+import com.weiver.essay.domain.EssayAnswer;
+import com.weiver.essay.domain.EssayQuestion;
+import com.weiver.essay.repository.EssayAnswerRepository;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.publisher.DomainEventPublisher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicantProfileEventServiceTest {
+
+    @InjectMocks
+    private ApplicantProfileEventService applicantProfileEventService;
+
+    @Mock private ApplicantRepository applicantRepository;
+    @Mock private EducationRepository educationRepository;
+    @Mock private WorkExperienceRepository workExperienceRepository;
+    @Mock private CertificateRepository certificateRepository;
+    @Mock private EssayAnswerRepository essayAnswerRepository;
+    @Mock private DomainEventPublisher domainEventPublisher;
+
+    @Test
+    @DisplayName("지원자 프로필 변경 이벤트 payload를 구성하고 동기화 상태를 REQUESTED로 바꾼다")
+    void publishProfileChanged_BuildsPayloadAndMarksRequested() {
+        Applicant applicant = Applicant.builder()
+                .applicantId(1L)
+                .name("홍길동")
+                .build();
+        Education education = Education.builder()
+                .educationId(10L)
+                .degree(Degree.BACHELOR)
+                .schoolName("한양대학교")
+                .major("컴퓨터공학")
+                .gpa(BigDecimal.valueOf(4.0))
+                .startDate(YearMonth.of(2020, 3))
+                .endDate(YearMonth.of(2024, 2))
+                .status(Status.GRADUATED)
+                .applicant(applicant)
+                .build();
+        WorkExperience experience = WorkExperience.builder()
+                .experienceId(20L)
+                .companyName("Weiver")
+                .startDate(LocalDate.of(2024, 1, 1))
+                .employmentType(EmploymentType.FULL_TIME)
+                .position("Backend Engineer")
+                .duties("API 개발")
+                .isRecognized(true)
+                .applicant(applicant)
+                .build();
+        Certificate certificate = Certificate.builder()
+                .certificateId(30L)
+                .certificateName("정보처리기사")
+                .issuer("한국산업인력공단")
+                .acquisitionDate(LocalDate.of(2023, 6, 1))
+                .applicant(applicant)
+                .build();
+        EssayQuestion question = EssayQuestion.builder()
+                .questionId(40L)
+                .sequence(1)
+                .maxLength(500)
+                .question("자기소개")
+                .build();
+        EssayAnswer answer = EssayAnswer.builder()
+                .answerId(50L)
+                .answer("답변 본문")
+                .applicant(applicant)
+                .essayQuestion(question)
+                .build();
+
+        given(applicantRepository.findById(1L)).willReturn(Optional.of(applicant));
+        given(educationRepository.findAllByApplicant(applicant)).willReturn(List.of(education));
+        given(workExperienceRepository.findAllByApplicantOrderByStartDateDesc(applicant)).willReturn(List.of(experience));
+        given(certificateRepository.findAllByApplicant(applicant)).willReturn(List.of(certificate));
+        given(essayAnswerRepository.findAllByApplicantWithQuestionOrderBySequence(applicant)).willReturn(List.of(answer));
+
+        applicantProfileEventService.publishProfileChanged(1L);
+
+        ArgumentCaptor<EventEnvelope<?>> captor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(domainEventPublisher).publish(captor.capture());
+
+        EventEnvelope<?> envelope = captor.getValue();
+        assertThat(envelope.eventType()).isEqualTo(EventType.APPLICANT_PROFILE_CHANGED);
+        assertThat(envelope.data()).isInstanceOf(ApplicantProfileChangedData.class);
+
+        ApplicantProfileChangedData data = (ApplicantProfileChangedData) envelope.data();
+        assertThat(data.applicantId()).isEqualTo(1L);
+        assertThat(data.educations()).hasSize(1);
+        assertThat(data.educations().get(0).schoolName()).isEqualTo("한양대학교");
+        assertThat(data.experiences().get(0).companyName()).isEqualTo("Weiver");
+        assertThat(data.certifications()).containsExactly("정보처리기사");
+        assertThat(data.essay().get(0).question()).isEqualTo("자기소개");
+        assertThat(applicant.getProfileSyncStatus()).isEqualTo(ProfileSyncStatus.REQUESTED);
+    }
+}

--- a/src/test/java/com/weiver/applicant/event/handler/ApplicantProfileSyncCompletedHandlerTest.java
+++ b/src/test/java/com/weiver/applicant/event/handler/ApplicantProfileSyncCompletedHandlerTest.java
@@ -1,0 +1,80 @@
+package com.weiver.applicant.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.analysis.event.ApplicantAnalysisEventService;
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.event.dto.ApplicantProfileSyncCompletedData;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.applicant.type.ProfileSyncStatus;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.NonRetryableEventException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicantProfileSyncCompletedHandlerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock private ApplicantRepository applicantRepository;
+    @Mock private ApplicantAnalysisEventService applicantAnalysisEventService;
+
+    @Test
+    @DisplayName("프로필 동기화 완료 payload에 synced가 없으면 non-retryable 예외가 발생한다")
+    void handle_ThrowsNonRetryable_WhenSyncedIsMissing() {
+        ApplicantProfileSyncCompletedHandler handler = new ApplicantProfileSyncCompletedHandler(
+                objectMapper,
+                applicantRepository,
+                applicantAnalysisEventService
+        );
+        ApplicantProfileSyncCompletedData data = new ApplicantProfileSyncCompletedData(1L, null);
+
+        assertThatThrownBy(() -> handler.handle(envelope(data)))
+                .isInstanceOf(NonRetryableEventException.class)
+                .hasMessage("synced is required");
+    }
+
+    @Test
+    @DisplayName("이미 동기화 완료된 지원자는 지연된 실패 이벤트로 FAILED 상태가 되지 않는다")
+    void handle_DoesNotDowngradeCompletedApplicant() {
+        ApplicantProfileSyncCompletedHandler handler = new ApplicantProfileSyncCompletedHandler(
+                objectMapper,
+                applicantRepository,
+                applicantAnalysisEventService
+        );
+        Applicant applicant = Applicant.builder().applicantId(1L).build();
+        applicant.markProfileSyncCompleted(OffsetDateTime.now());
+
+        given(applicantRepository.findById(1L)).willReturn(Optional.of(applicant));
+
+        handler.handle(envelope(new ApplicantProfileSyncCompletedData(1L, false)));
+
+        assertThat(applicant.getProfileSyncStatus()).isEqualTo(ProfileSyncStatus.COMPLETED);
+        verify(applicantAnalysisEventService, never()).publishApplicantAnalysisRequested(1L);
+    }
+
+    private EventEnvelope<JsonNode> envelope(ApplicantProfileSyncCompletedData data) {
+        return new EventEnvelope<>(
+                "event-1",
+                EventType.APPLICANT_PROFILE_SYNC_COMPLETED,
+                null,
+                OffsetDateTime.now(),
+                EventEnvelope.CURRENT_VERSION,
+                objectMapper.valueToTree(data)
+        );
+    }
+}

--- a/src/test/java/com/weiver/applicant/service/ApplicantServiceImplTest.java
+++ b/src/test/java/com/weiver/applicant/service/ApplicantServiceImplTest.java
@@ -8,6 +8,7 @@ import com.weiver.applicant.dto.request.post.EducationRequestDTO;
 import com.weiver.applicant.dto.request.put.ApplicantInfoRequestDTO;
 import com.weiver.applicant.dto.response.ApplicantDocumentStatusResponseDTO;
 import com.weiver.applicant.dto.response.ApplicantInfoResponseDTO;
+import com.weiver.applicant.event.ApplicantProfileEventService;
 import com.weiver.applicant.repository.*;
 import com.weiver.essay.repository.EssayAnswerRepository;
 import com.weiver.applicant.type.Degree;
@@ -50,6 +51,7 @@ class ApplicantServiceImplTest {
     @Mock private EssayAnswerRepository essayAnswerRepository;
     @Mock private PortfolioRepository portfolioRepository;
     @Mock private S3Service s3Service;
+    @Mock private ApplicantProfileEventService applicantProfileEventService;
 
     @InjectMocks
     private ApplicantService applicantService;

--- a/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
+++ b/src/test/java/com/weiver/essay/service/EssayAnswerServiceTest.java
@@ -1,6 +1,7 @@
 package com.weiver.essay.service;
 
 import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.event.ApplicantProfileEventService;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.essay.domain.EssayAnswer;
 import com.weiver.essay.domain.EssayQuestion;
@@ -41,6 +42,9 @@ class EssayAnswerServiceTest {
 
     @Mock
     private ApplicantRepository applicantRepository;
+
+    @Mock
+    private ApplicantProfileEventService applicantProfileEventService;
 
     @InjectMocks
     private EssayAnswerService essayAnswerService;

--- a/src/test/java/com/weiver/jobposting/event/JobPostingEventServiceTest.java
+++ b/src/test/java/com/weiver/jobposting/event/JobPostingEventServiceTest.java
@@ -1,0 +1,82 @@
+package com.weiver.jobposting.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.company.domain.Company;
+import com.weiver.company.type.DecisionMaking;
+import com.weiver.company.type.OperationStyle;
+import com.weiver.company.type.RoleDefinition;
+import com.weiver.company.type.WorkPace;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.publisher.DomainEventPublisher;
+import com.weiver.jobposting.domain.JobPosting;
+import com.weiver.jobposting.event.dto.JdAnalysisRequestedData;
+import com.weiver.jobposting.type.JobPostingStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JobPostingEventServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private JobPostingEventService jobPostingEventService;
+
+    @Mock private DomainEventPublisher domainEventPublisher;
+
+    @Test
+    @DisplayName("JD 분석 요청 payload의 업무 방식은 company type enum을 그대로 사용한다")
+    void publishJdAnalysisRequested_UsesCompanyTypeEnums() {
+        Company company = Company.builder()
+                .companyId(1L)
+                .cultureDescription("빠르게 실험합니다.")
+                .directionDescription("안정적으로 확장합니다.")
+                .workPace(WorkPace.FAST_EXECUTION)
+                .decisionMaking(DecisionMaking.TEAM_CONSENSUS)
+                .roleDefinition(RoleDefinition.CLEAR_RESPONSIBILITY)
+                .operationStyle(OperationStyle.EXPERIMENT_ORIENTED)
+                .build();
+        JobPosting jobPosting = JobPosting.builder()
+                .jdId(10L)
+                .company(company)
+                .status(JobPostingStatus.ACTIVE)
+                .title("백엔드 개발자")
+                .jobCategory("개발")
+                .detailedJob("백엔드")
+                .requiredTech(List.of("Java"))
+                .build();
+
+        jobPostingEventService.publishJdAnalysisRequested(jobPosting);
+
+        ArgumentCaptor<EventEnvelope<?>> captor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(domainEventPublisher).publish(captor.capture());
+
+        EventEnvelope<?> envelope = captor.getValue();
+        assertThat(envelope.eventType()).isEqualTo(EventType.JD_ANALYSIS_REQUESTED);
+        assertThat(envelope.data()).isInstanceOf(JdAnalysisRequestedData.class);
+
+        JdAnalysisRequestedData data = (JdAnalysisRequestedData) envelope.data();
+        assertThat(data.workStyle().progressSpeed()).isEqualTo(WorkPace.FAST_EXECUTION);
+        assertThat(data.workStyle().decisionMaker()).isEqualTo(DecisionMaking.TEAM_CONSENSUS);
+        assertThat(data.workStyle().roleDefinition()).isEqualTo(RoleDefinition.CLEAR_RESPONSIBILITY);
+        assertThat(data.workStyle().operatingSystem()).isEqualTo(OperationStyle.EXPERIMENT_ORIENTED);
+
+        JsonNode workStyleJson = objectMapper.valueToTree(data.workStyle());
+        assertThat(workStyleJson.get("progress_speed").asText()).isEqualTo("FAST_EXECUTION");
+        assertThat(workStyleJson.get("decision_maker").asText()).isEqualTo("TEAM_CONSENSUS");
+        assertThat(workStyleJson.get("role_definition").asText()).isEqualTo("CLEAR_RESPONSIBILITY");
+        assertThat(workStyleJson.get("operating_system").asText()).isEqualTo("EXPERIMENT_ORIENTED");
+    }
+}

--- a/src/test/java/com/weiver/jobposting/event/handler/JdAnalysisCompletedHandlerTest.java
+++ b/src/test/java/com/weiver/jobposting/event/handler/JdAnalysisCompletedHandlerTest.java
@@ -49,7 +49,7 @@ class JdAnalysisCompletedHandlerTest {
                 .build();
         JdAnalysisCompletedData data = new JdAnalysisCompletedData(
                 10L,
-                2L,
+                999L,
                 "original jd text",
                 List.of(0.1, 0.2, 0.3)
         );

--- a/src/test/java/com/weiver/jobposting/event/handler/JdAnalysisCompletedHandlerTest.java
+++ b/src/test/java/com/weiver/jobposting/event/handler/JdAnalysisCompletedHandlerTest.java
@@ -1,0 +1,83 @@
+package com.weiver.jobposting.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.analysis.domain.JdAnalysisResult;
+import com.weiver.analysis.repository.JdAnalysisResultRepository;
+import com.weiver.company.domain.Company;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.jobposting.domain.JobPosting;
+import com.weiver.jobposting.event.dto.JdAnalysisCompletedData;
+import com.weiver.jobposting.repository.JobPostingRepository;
+import com.weiver.jobposting.type.JdAnalysisStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JdAnalysisCompletedHandlerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock private JobPostingRepository jobPostingRepository;
+    @Mock private JdAnalysisResultRepository jdAnalysisResultRepository;
+
+    @Test
+    @DisplayName("JD 분석 완료 이벤트를 수신하면 JD 분석 결과를 저장하고 공고 상태를 COMPLETED로 바꾼다")
+    void handle_SavesJdAnalysisResultAndMarksCompleted() {
+        JdAnalysisCompletedHandler handler = new JdAnalysisCompletedHandler(
+                objectMapper,
+                jobPostingRepository,
+                jdAnalysisResultRepository
+        );
+        Company company = Company.builder().companyId(2L).build();
+        JobPosting jobPosting = JobPosting.builder()
+                .jdId(10L)
+                .company(company)
+                .build();
+        JdAnalysisCompletedData data = new JdAnalysisCompletedData(
+                10L,
+                2L,
+                "original jd text",
+                List.of(0.1, 0.2, 0.3)
+        );
+
+        given(jobPostingRepository.findById(10L)).willReturn(Optional.of(jobPosting));
+        given(jdAnalysisResultRepository.findByJobPosting_JdId(10L)).willReturn(Optional.empty());
+
+        handler.handle(envelope(data));
+
+        ArgumentCaptor<JdAnalysisResult> captor = ArgumentCaptor.forClass(JdAnalysisResult.class);
+        verify(jdAnalysisResultRepository).save(captor.capture());
+
+        JdAnalysisResult saved = captor.getValue();
+        assertThat(saved.getJobPosting()).isEqualTo(jobPosting);
+        assertThat(saved.getCompanyId()).isEqualTo(2L);
+        assertThat(saved.getOriginalText()).isEqualTo("original jd text");
+        assertThat(saved.getEmbedding()).containsExactly(0.1, 0.2, 0.3);
+        assertThat(jobPosting.getJdAnalysisStatus()).isEqualTo(JdAnalysisStatus.COMPLETED);
+    }
+
+    private EventEnvelope<JsonNode> envelope(JdAnalysisCompletedData data) {
+        return new EventEnvelope<>(
+                "event-1",
+                EventType.JD_ANALYSIS_COMPLETED,
+                null,
+                OffsetDateTime.now(),
+                EventEnvelope.CURRENT_VERSION,
+                objectMapper.valueToTree(data)
+        );
+    }
+}

--- a/src/test/java/com/weiver/jobposting/service/JobPostingServiceTest.java
+++ b/src/test/java/com/weiver/jobposting/service/JobPostingServiceTest.java
@@ -64,6 +64,30 @@ class JobPostingServiceTest {
     }
 
     @Test
+    @DisplayName("공고 생성 성공: isTemp가 null이면 ACTIVE로 저장하고 JD 분석 요청을 발행한다")
+    void saveJobPosting_NullIsTemp_RequestsJdAnalysis() {
+        // given
+        String publicId = "2222";
+        JobPostingRequestDTO requestDTO = mock(JobPostingRequestDTO.class);
+        Company company = mock(Company.class);
+        JobPosting jobPosting = mock(JobPosting.class);
+        EmailTemplate emailTemplate = mock(EmailTemplate.class);
+
+        given(companyRepository.findByPublicId(publicId)).willReturn(Optional.of(company));
+        given(requestDTO.toJobPosting(company, JobPostingStatus.ACTIVE)).willReturn(jobPosting);
+        given(jobPostingRepository.save(jobPosting)).willReturn(jobPosting);
+        given(requestDTO.toEmailTemplate(jobPosting, null)).willReturn(emailTemplate);
+
+        // when
+        jobPostingService.saveJobPosting(null, publicId, requestDTO, null);
+
+        // then
+        verify(jobPostingRepository).save(jobPosting);
+        verify(emailTemplateRepository).save(emailTemplate);
+        verify(jobPostingEventService).publishJdAnalysisRequested(jobPosting);
+    }
+
+    @Test
     @DisplayName("공고 생성 실패: 존재하지 않는 회사 ID인 경우 예외 발생")
     void saveJobPosting_CompanyNotFound() {
         // given

--- a/src/test/java/com/weiver/jobposting/service/JobPostingServiceTest.java
+++ b/src/test/java/com/weiver/jobposting/service/JobPostingServiceTest.java
@@ -8,6 +8,7 @@ import com.weiver.jobposting.domain.EmailTemplate;
 import com.weiver.jobposting.domain.JobPosting;
 import com.weiver.jobposting.dto.request.JobPostingRequestDTO;
 import com.weiver.jobposting.dto.request.JobPostingUpdateDTO;
+import com.weiver.jobposting.event.JobPostingEventService;
 import com.weiver.jobposting.repository.EmailTemplateRepository;
 import com.weiver.jobposting.repository.JobPostingRepository;
 import com.weiver.jobposting.type.JobPostingStatus;
@@ -36,6 +37,7 @@ class JobPostingServiceTest {
     @Mock private JobPostingRepository jobPostingRepository;
     @Mock private CompanyRepository companyRepository;
     @Mock private S3Service s3Service;
+    @Mock private JobPostingEventService jobPostingEventService;
 
     @Test
     @DisplayName("공고 생성 성공: 임시저장이면 상태가 DRAFT이고 이미지가 없으면 S3를 호출하지 않는다")

--- a/src/test/java/com/weiver/matching/controller/MatchResultControllerTest.java
+++ b/src/test/java/com/weiver/matching/controller/MatchResultControllerTest.java
@@ -1,6 +1,5 @@
 package com.weiver.matching.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.weiver.analysis.type.CulturefitStyle;
 import com.weiver.global.common.UserRole;
 import com.weiver.global.security.cookie.CookieProvider;
@@ -47,9 +46,6 @@ class MatchResultControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockitoBean
     private MatchResultService matchResultService;

--- a/src/test/java/com/weiver/matching/event/MatchingEventServiceTest.java
+++ b/src/test/java/com/weiver/matching/event/MatchingEventServiceTest.java
@@ -1,0 +1,72 @@
+package com.weiver.matching.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.company.domain.Company;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.publisher.DomainEventPublisher;
+import com.weiver.jobposting.domain.JobPosting;
+import com.weiver.jobposting.repository.JobPostingRepository;
+import com.weiver.jobposting.type.JobPostingStatus;
+import com.weiver.matching.event.dto.MatchingRequestedData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingEventServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private MatchingEventService matchingEventService;
+
+    @Mock private JobPostingRepository jobPostingRepository;
+    @Mock private DomainEventPublisher domainEventPublisher;
+
+    @Test
+    @DisplayName("매칭 요청 payload에는 공고 기술 스택과 요구사항만 포함하고 우선순위는 포함하지 않는다")
+    void publishMatchingRequested_PayloadWithoutPriorities() {
+        Company company = Company.builder()
+                .companyId(1L)
+                .build();
+        JobPosting jobPosting = JobPosting.builder()
+                .jdId(10L)
+                .company(company)
+                .status(JobPostingStatus.ACTIVE)
+                .requiredTech(List.of("Java", "Spring"))
+                .requirements("Spring Boot 경험")
+                .competencyPriorities(List.of("문제해결력"))
+                .traitPriorities(List.of("자율"))
+                .build();
+
+        given(jobPostingRepository.findById(10L)).willReturn(Optional.of(jobPosting));
+
+        matchingEventService.publishMatchingRequested(10L);
+
+        ArgumentCaptor<EventEnvelope<?>> captor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(domainEventPublisher).publish(captor.capture());
+
+        EventEnvelope<?> envelope = captor.getValue();
+        assertThat(envelope.eventType()).isEqualTo(EventType.MATCHING_REQUESTED);
+        assertThat(envelope.data()).isInstanceOf(MatchingRequestedData.class);
+
+        JsonNode json = objectMapper.valueToTree(envelope.data());
+        assertThat(json.get("required_skills").get(0).asText()).isEqualTo("Java");
+        assertThat(json.get("requirements").asText()).isEqualTo("Spring Boot 경험");
+        assertThat(json.has("competency_priorities")).isFalse();
+        assertThat(json.has("trait_priorities")).isFalse();
+    }
+}

--- a/src/test/java/com/weiver/matching/event/handler/MatchingCompletedHandlerTest.java
+++ b/src/test/java/com/weiver/matching/event/handler/MatchingCompletedHandlerTest.java
@@ -6,6 +6,7 @@ import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.global.event.dto.EventEnvelope;
 import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.NonRetryableEventException;
 import com.weiver.jobposting.domain.JobPosting;
 import com.weiver.jobposting.repository.JobPostingRepository;
 import com.weiver.matching.domain.MatchResult;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
@@ -81,6 +83,28 @@ class MatchingCompletedHandlerTest {
         assertThat(saved.get(0).getFinalScore()).isEqualTo(89.0f);
         assertThat(saved.get(0).getMatchingRate()).isEqualTo(89.0f);
         assertThat(saved.get(0).getAiSummary()).isEqualTo("요약");
+    }
+
+    @Test
+    @DisplayName("매칭 완료 payload에 같은 applicant_id가 중복되면 non-retryable 예외가 발생한다")
+    void handle_ThrowsNonRetryable_WhenApplicantIdIsDuplicated() {
+        MatchingCompletedHandler handler = new MatchingCompletedHandler(
+                objectMapper,
+                jobPostingRepository,
+                applicantRepository,
+                matchResultRepository
+        );
+        MatchingCompletedData data = new MatchingCompletedData(
+                10L,
+                List.of(
+                        new MatchingCompletedData.MatchData(1L, 87.5f, 91.0f, 89.0f, "요약 1"),
+                        new MatchingCompletedData.MatchData(1L, 80.0f, 82.0f, 81.0f, "요약 2")
+                )
+        );
+
+        assertThatThrownBy(() -> handler.handle(envelope(data)))
+                .isInstanceOf(NonRetryableEventException.class)
+                .hasMessage("Duplicate applicant_id in matches: 1");
     }
 
     private EventEnvelope<JsonNode> envelope(MatchingCompletedData data) {

--- a/src/test/java/com/weiver/matching/event/handler/MatchingCompletedHandlerTest.java
+++ b/src/test/java/com/weiver/matching/event/handler/MatchingCompletedHandlerTest.java
@@ -1,0 +1,96 @@
+package com.weiver.matching.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.jobposting.domain.JobPosting;
+import com.weiver.jobposting.repository.JobPostingRepository;
+import com.weiver.matching.domain.MatchResult;
+import com.weiver.matching.event.dto.MatchingCompletedData;
+import com.weiver.matching.repository.MatchResultRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingCompletedHandlerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock private JobPostingRepository jobPostingRepository;
+    @Mock private ApplicantRepository applicantRepository;
+    @Mock private MatchResultRepository matchResultRepository;
+
+    @Test
+    @DisplayName("매칭 완료 이벤트를 수신하면 기존 결과를 삭제 후 새 결과를 저장한다")
+    void handle_ReplacesMatchResults() {
+        MatchingCompletedHandler handler = new MatchingCompletedHandler(
+                objectMapper,
+                jobPostingRepository,
+                applicantRepository,
+                matchResultRepository
+        );
+        JobPosting jobPosting = JobPosting.builder().jdId(10L).build();
+        Applicant applicant = Applicant.builder().applicantId(1L).build();
+        MatchingCompletedData data = new MatchingCompletedData(
+                10L,
+                List.of(new MatchingCompletedData.MatchData(
+                        1L,
+                        87.5f,
+                        91.0f,
+                        89.0f,
+                        "요약"
+                ))
+        );
+
+        given(jobPostingRepository.findById(10L)).willReturn(Optional.of(jobPosting));
+        given(applicantRepository.findById(1L)).willReturn(Optional.of(applicant));
+
+        handler.handle(envelope(data));
+
+        InOrder inOrder = inOrder(matchResultRepository);
+        inOrder.verify(matchResultRepository).deleteByJobPosting_JdId(10L);
+        inOrder.verify(matchResultRepository).flush();
+        inOrder.verify(matchResultRepository).saveAll(org.mockito.ArgumentMatchers.any());
+
+        ArgumentCaptor<Iterable<MatchResult>> captor = ArgumentCaptor.forClass(Iterable.class);
+        verify(matchResultRepository).saveAll(captor.capture());
+        List<MatchResult> saved = ((List<MatchResult>) captor.getValue());
+
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getJobPosting()).isEqualTo(jobPosting);
+        assertThat(saved.get(0).getApplicant()).isEqualTo(applicant);
+        assertThat(saved.get(0).getSkillScore()).isEqualTo(87.5f);
+        assertThat(saved.get(0).getCulturefitScore()).isEqualTo(91.0f);
+        assertThat(saved.get(0).getFinalScore()).isEqualTo(89.0f);
+        assertThat(saved.get(0).getMatchingRate()).isEqualTo(89.0f);
+        assertThat(saved.get(0).getAiSummary()).isEqualTo("요약");
+    }
+
+    private EventEnvelope<JsonNode> envelope(MatchingCompletedData data) {
+        return new EventEnvelope<>(
+                "event-1",
+                EventType.MATCHING_COMPLETED,
+                null,
+                OffsetDateTime.now(),
+                EventEnvelope.CURRENT_VERSION,
+                objectMapper.valueToTree(data)
+        );
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명
RabbitMQ 기반으로 지원자 프로필 동기화, 지원자 분석, JD 분석, 매칭 요청/완료 저장 흐름을 구현했습니다.
수동 매칭 실행 API는 제외했고, 추후 스케줄러에서 `MatchingEventService`를 호출해 매일 특정 시간에 매칭 요청을 발행할 수 있도록 내부 서비스만 구성했습니다.

## 📝 Summary
- 지원자 정보/학력/경력/자격증/자기소개서 변경 시 `APPLICANT_PROFILE_CHANGED` 이벤트 발행
- `APPLICANT_PROFILE_SYNC_COMPLETED` 수신 후 `APPLICANT_ANALYSIS_REQUESTED` 발행
- `APPLICANT_ANALYSIS_COMPLETED` 수신 시 기술/컬처 리포트 upsert
- ACTIVE 공고 생성 및 분석 대상 필드 수정 시 `JD_ANALYSIS_REQUESTED` 발행
- `JD_ANALYSIS_COMPLETED` 수신 시 `JdAnalysisResult` 저장 및 공고 분석 상태 갱신
- `MATCHING_REQUESTED` 발행 서비스 추가
- `MATCHING_COMPLETED` 수신 시 기존 매칭 결과 삭제 후 최신 결과 저장
- 이벤트 payload/handler 중심 단위 테스트 추가

## 🙏 Question & PR point
- `JdAnalysisRequestedData.WorkStyleData`는 기존 company type enum(`WorkPace`, `DecisionMaking`, `RoleDefinition`, `OperationStyle`)을 그대로 사용합니다.
- 매칭 요청은 API가 아니라 추후 scheduler에서 `MatchingEventService`를 호출하는 방식으로 확장하면 됩니다.
- 후속 작업으로 DB upsert 또는 lock 기반 멱등성 강화 예정입니다.

## 📬 Postman
RabbitMQ 비동기 이벤트/handler 중심 작업이라 Postman 스크린샷은 없습니다.

## 📣 Related Issue
- close #76 

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event-driven applicant analysis to generate and persist technical skills, culture fit, and job/role details
  * Introduced job description analysis and store embeddings to support improved matching
  * Automatically triggers analysis and matching when relevant applicant profile or job posting data changes
  * Added support for storing JD and matching outcomes (including AI summary reasons)

* **Improvements**
  * Improved reliability of analysis workflow transitions
  * Enforced uniqueness and idempotent upserts for analysis and matching results
  * Added validation to prevent duplicate match applicants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->