### PR TITLE
[Feature] WebSocket 기반 AI 면접 플로우 구현

### DIFF
--- a/src/main/java/com/weiver/analysis/domain/DetailAnalysisReport.java
+++ b/src/main/java/com/weiver/analysis/domain/DetailAnalysisReport.java
@@ -47,4 +47,8 @@ public class DetailAnalysisReport extends BaseTimeEntity {
     @JoinColumn(name = "interview_session_id", referencedColumnName = "interview_session_id", nullable = false, unique = true)
     private InterviewSession interviewSession;
 
+    public void updateAnalysis(Map<String, Object> skillAnalysis, Map<String, Object> cultureAnalysis) {
+        this.skillAnalysis = skillAnalysis;
+        this.cultureAnalysis = cultureAnalysis;
+    }
 }

--- a/src/main/java/com/weiver/analysis/repository/DetailAnalysisReportRepository.java
+++ b/src/main/java/com/weiver/analysis/repository/DetailAnalysisReportRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface DetailAnalysisReportRepository extends JpaRepository<DetailAnalysisReport, Long> {
-    Optional<DetailAnalysisReport> findByApplicant_PublicId(String applicantPublicId);
+    Optional<DetailAnalysisReport> findTopByApplicant_PublicIdOrderByCreateTimeDesc(String applicantPublicId);
     Optional<DetailAnalysisReport> findByInterviewSession_InterviewSessionId(UUID interviewSessionId);
 }

--- a/src/main/java/com/weiver/analysis/service/ReportService.java
+++ b/src/main/java/com/weiver/analysis/service/ReportService.java
@@ -47,7 +47,7 @@ public class ReportService {
      * 매칭 결과 검증 - 해당 공고에 대한 매칭 결과가 존재하는지 검증 (DetailAnalysisReport 존재 여부로 검증)
      * */
     public DetailAnalysisReport getDetailAnalysisReport(String applicantPublicId) {
-        return detailAnalysisReportRepository.findByApplicant_PublicId(applicantPublicId)
+        return detailAnalysisReportRepository.findTopByApplicant_PublicIdOrderByCreateTimeDesc(applicantPublicId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
     }
 

--- a/src/main/java/com/weiver/global/config/SecurityConfig.java
+++ b/src/main/java/com/weiver/global/config/SecurityConfig.java
@@ -53,8 +53,11 @@ public class SecurityConfig {
                 .csrfTokenRequestHandler(requestHandler)
                 .ignoringRequestMatchers(
                         Stream.concat(
-                                WhiteListConfig.applicantAuthWhitelist().stream(),
-                                WhiteListConfig.companyAuthWhitelist().stream()
+                                Stream.concat(
+                                        WhiteListConfig.applicantAuthWhitelist().stream(),
+                                        WhiteListConfig.companyAuthWhitelist().stream()
+                                ),
+                                Stream.of("/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**")
                         ).toArray(String[]::new)
                 )
         );
@@ -81,6 +84,10 @@ public class SecurityConfig {
                         .requestMatchers(WhiteListConfig.swaggerWhitelist().toArray(String[]::new)).permitAll()
                         .requestMatchers(WhiteListConfig.serverWhitelist().toArray(String[]::new)).permitAll()
                         .requestMatchers(WhiteListConfig.authWhitelist().toArray(String[]::new)).permitAll()
+                        .requestMatchers("/ws").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers("/ws-sockjs").permitAll()
+                        .requestMatchers("/ws-sockjs/**").permitAll()
 
                         .requestMatchers(
                                 HttpMethod.POST,

--- a/src/main/java/com/weiver/global/config/WebSocketConfig.java
+++ b/src/main/java/com/weiver/global/config/WebSocketConfig.java
@@ -1,0 +1,48 @@
+package com.weiver.global.config;
+
+import com.weiver.global.security.websocket.WebSocketAuthChannelInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketAuthChannelInterceptor webSocketAuthChannelInterceptor;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-sockjs")
+                .setAllowedOrigins(
+                        "https://www.piuda.site",
+                        "https://weiver.local.piuda.site:3000",
+                        "http://localhost:3000"
+                );
+
+        registry.addEndpoint("/ws")
+                .setAllowedOrigins(
+                        "https://www.piuda.site",
+                        "https://weiver.local.piuda.site:3000",
+                        "http://localhost:3000"
+                )
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/queue", "/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketAuthChannelInterceptor);
+    }
+}

--- a/src/main/java/com/weiver/global/config/WebSocketConfig.java
+++ b/src/main/java/com/weiver/global/config/WebSocketConfig.java
@@ -18,14 +18,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws-sockjs")
+        registry.addEndpoint("/ws")
                 .setAllowedOrigins(
                         "https://www.piuda.site",
                         "https://weiver.local.piuda.site:3000",
                         "http://localhost:3000"
                 );
 
-        registry.addEndpoint("/ws")
+        registry.addEndpoint("/ws-sockjs")
                 .setAllowedOrigins(
                         "https://www.piuda.site",
                         "https://weiver.local.piuda.site:3000",

--- a/src/main/java/com/weiver/global/security/principal/AuthenticatedPrincipal.java
+++ b/src/main/java/com/weiver/global/security/principal/AuthenticatedPrincipal.java
@@ -2,8 +2,14 @@ package com.weiver.global.security.principal;
 
 import com.weiver.global.common.UserRole;
 
+import java.security.Principal;
+
 public record AuthenticatedPrincipal(
         String publicId,
         UserRole role
-) {
+) implements Principal {
+    @Override
+    public String getName() {
+        return publicId;
+    }
 }

--- a/src/main/java/com/weiver/global/security/websocket/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/com/weiver/global/security/websocket/WebSocketAuthChannelInterceptor.java
@@ -1,0 +1,89 @@
+package com.weiver.global.security.websocket;
+
+import com.weiver.global.common.UserRole;
+import com.weiver.global.security.jwt.BearerTokenResolver;
+import com.weiver.global.security.jwt.JwtTokenProvider;
+import com.weiver.global.security.jwt.repository.BlacklistTokenRepository;
+import com.weiver.global.security.jwt.repository.TokenVersionRepository;
+import com.weiver.global.security.principal.AuthenticatedPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
+
+    private static final String ACCESS_TOKEN_HEADER = "access_token";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final BlacklistTokenRepository blacklistTokenRepository;
+    private final TokenVersionRepository tokenVersionRepository;
+    private final BearerTokenResolver bearerTokenResolver;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null || accessor.getCommand() != StompCommand.CONNECT) {
+            return message;
+        }
+
+        String accessToken = resolveAccessToken(accessor);
+        if (accessToken == null) {
+            throw new AccessDeniedException("WebSocket access token is required");
+        }
+        if (blacklistTokenRepository.exists(accessToken)) {
+            throw new AccessDeniedException("Blacklisted WebSocket access token");
+        }
+
+        String publicId = jwtTokenProvider.getPublicId(accessToken);
+        UserRole userRole = jwtTokenProvider.getRole(accessToken);
+        long tokenVersion = jwtTokenProvider.getTokenVersion(accessToken);
+        long currentTokenVersion = tokenVersionRepository.getCurrentVersion(publicId, userRole);
+
+        if (tokenVersion != currentTokenVersion) {
+            throw new AccessDeniedException("Invalid WebSocket access token version");
+        }
+
+        AuthenticatedPrincipal principal = new AuthenticatedPrincipal(publicId, userRole);
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_" + userRole.name()))
+        );
+
+        accessor.setUser(authentication);
+        return message;
+    }
+
+    private String resolveAccessToken(StompHeaderAccessor accessor) {
+        String authorizationHeader = firstNativeHeader(accessor, HttpHeaders.AUTHORIZATION);
+        String accessToken = bearerTokenResolver.resolve(authorizationHeader);
+        if (accessToken != null) {
+            return accessToken;
+        }
+
+        return firstNativeHeader(accessor, ACCESS_TOKEN_HEADER);
+    }
+
+    private String firstNativeHeader(StompHeaderAccessor accessor, String headerName) {
+        List<String> values = accessor.getNativeHeader(headerName);
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+
+        String value = values.get(0);
+        return value != null && !value.isBlank() ? value : null;
+    }
+}

--- a/src/main/java/com/weiver/interview/domain/InterviewSession.java
+++ b/src/main/java/com/weiver/interview/domain/InterviewSession.java
@@ -9,7 +9,9 @@ import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -47,8 +49,9 @@ public class InterviewSession extends BaseTimeEntity {
     private String currentQuestion;
 
     @JdbcTypeCode(SqlTypes.JSON)
+    @Builder.Default
     @Column(name = "transcript", nullable = false, columnDefinition = "jsonb")
-    private List<InterviewTurnDTO> transcript;
+    private List<InterviewTurnDTO> transcript = new ArrayList<>();
 
     @Column(name = "video_url")
     private String videoUrl;
@@ -69,5 +72,55 @@ public class InterviewSession extends BaseTimeEntity {
 
     public void updateStatus(InterviewSessionStatus sessionStatus) {
         this.sessionStatus = sessionStatus;
+    }
+
+    public List<InterviewTurnDTO> getTranscript() {
+        return transcript != null ? transcript : List.of();
+    }
+
+    public boolean hasTurn(String questionCode, Integer sequence) {
+        return getTranscript().stream()
+                .anyMatch(turn -> matches(turn, questionCode, sequence));
+    }
+
+    public boolean appendQuestion(String questionCode, Integer sequence, String question) {
+        List<InterviewTurnDTO> turns = new ArrayList<>(getTranscript());
+        boolean duplicated = turns.stream()
+                .anyMatch(turn -> matches(turn, questionCode, sequence));
+
+        if (duplicated) {
+            return false;
+        }
+
+        turns.add(InterviewTurnDTO.questionOnly(questionCode, sequence, question));
+        this.transcript = turns;
+        updateCurrentQuestion(sequence, questionCode, question);
+        return true;
+    }
+
+    public InterviewTurnDTO updateAnswer(String questionCode, Integer sequence, String answer) {
+        List<InterviewTurnDTO> turns = new ArrayList<>(getTranscript());
+
+        for (int i = 0; i < turns.size(); i++) {
+            InterviewTurnDTO turn = turns.get(i);
+            if (matches(turn, questionCode, sequence)) {
+                InterviewTurnDTO updated = turn.withAnswer(answer);
+                turns.set(i, updated);
+                this.transcript = turns;
+                updateCurrentQuestion(updated.sequence(), updated.questionCode(), updated.question());
+                return updated;
+            }
+        }
+
+        return null;
+    }
+
+    private boolean matches(InterviewTurnDTO turn, String questionCode, Integer sequence) {
+        if (turn == null) {
+            return false;
+        }
+
+        return Objects.equals(turn.questionCode(), questionCode)
+                || Objects.equals(turn.sequence(), sequence);
     }
 }

--- a/src/main/java/com/weiver/interview/domain/InterviewSession.java
+++ b/src/main/java/com/weiver/interview/domain/InterviewSession.java
@@ -78,11 +78,6 @@ public class InterviewSession extends BaseTimeEntity {
         return transcript != null ? transcript : List.of();
     }
 
-    public boolean hasTurn(String questionCode, Integer sequence) {
-        return getTranscript().stream()
-                .anyMatch(turn -> matches(turn, questionCode, sequence));
-    }
-
     public boolean appendQuestion(String questionCode, Integer sequence, String question) {
         List<InterviewTurnDTO> turns = new ArrayList<>(getTranscript());
         boolean duplicated = turns.stream()

--- a/src/main/java/com/weiver/interview/domain/InterviewSession.java
+++ b/src/main/java/com/weiver/interview/domain/InterviewSession.java
@@ -103,7 +103,7 @@ public class InterviewSession extends BaseTimeEntity {
 
         for (int i = 0; i < turns.size(); i++) {
             InterviewTurnDTO turn = turns.get(i);
-            if (matches(turn, questionCode, sequence)) {
+            if (matchesExactly(turn, questionCode, sequence)) {
                 InterviewTurnDTO updated = turn.withAnswer(answer);
                 turns.set(i, updated);
                 this.transcript = turns;
@@ -122,5 +122,14 @@ public class InterviewSession extends BaseTimeEntity {
 
         return Objects.equals(turn.questionCode(), questionCode)
                 || Objects.equals(turn.sequence(), sequence);
+    }
+
+    private boolean matchesExactly(InterviewTurnDTO turn, String questionCode, Integer sequence) {
+        if (turn == null) {
+            return false;
+        }
+
+        return Objects.equals(turn.questionCode(), questionCode)
+                && Objects.equals(turn.sequence(), sequence);
     }
 }

--- a/src/main/java/com/weiver/interview/dto/request/InterviewAnswerSubmitRequest.java
+++ b/src/main/java/com/weiver/interview/dto/request/InterviewAnswerSubmitRequest.java
@@ -1,0 +1,23 @@
+package com.weiver.interview.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "AI 면접 답변 제출 요청")
+public record InterviewAnswerSubmitRequest(
+        @NotBlank(message = "question_code는 필수입니다.")
+        @JsonProperty("question_code")
+        @Schema(description = "답변 대상 질문 코드", example = "S_01_00")
+        String questionCode,
+
+        @NotNull(message = "sequence는 필수입니다.")
+        @Schema(description = "답변 대상 질문 순서", example = "1")
+        Integer sequence,
+
+        @NotBlank(message = "answer는 필수입니다.")
+        @Schema(description = "지원자 답변", example = "프로젝트에서 Spring Boot와 JPA를 활용해 주문 도메인을 구현했습니다.")
+        String answer
+) {
+}

--- a/src/main/java/com/weiver/interview/dto/request/InterviewStartRequest.java
+++ b/src/main/java/com/weiver/interview/dto/request/InterviewStartRequest.java
@@ -1,0 +1,12 @@
+package com.weiver.interview.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "AI 면접 시작 요청")
+public record InterviewStartRequest(
+        @JsonProperty("interview_type")
+        @Schema(description = "면접 유형. 현재 MVP에서는 저장하지 않고 세션 UUID로 면접 실행 단위를 구분합니다.", example = "TECHNICAL")
+        String interviewSessionStatus
+) {
+}

--- a/src/main/java/com/weiver/interview/dto/request/InterviewStartRequest.java
+++ b/src/main/java/com/weiver/interview/dto/request/InterviewStartRequest.java
@@ -7,6 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record InterviewStartRequest(
         @JsonProperty("interview_type")
         @Schema(description = "면접 유형. 현재 MVP에서는 저장하지 않고 세션 UUID로 면접 실행 단위를 구분합니다.", example = "TECHNICAL")
-        String interviewSessionStatus
+        String interviewType
 ) {
 }

--- a/src/main/java/com/weiver/interview/dto/response/InterviewStartResponse.java
+++ b/src/main/java/com/weiver/interview/dto/response/InterviewStartResponse.java
@@ -1,0 +1,17 @@
+package com.weiver.interview.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "AI 면접 시작 응답")
+public record InterviewStartResponse(
+        @JsonProperty("interview_session_id")
+        @Schema(description = "면접 실행 단위 UUID")
+        UUID interviewSessionId,
+
+        @Schema(description = "현재 면접 세션 상태", example = "WAITING_FOR_QUESTION")
+        String status
+) {
+}

--- a/src/main/java/com/weiver/interview/dto/response/InterviewTurnDTO.java
+++ b/src/main/java/com/weiver/interview/dto/response/InterviewTurnDTO.java
@@ -17,4 +17,12 @@ public record InterviewTurnDTO(
 
         @Schema(description = "면접 답변", example = "프로젝트에서 주문 생성과 결제 승인 로직을 분리하면서 REQUIRED와 REQUIRES_NEW 전파 옵션의 차이를 경험했습니다.")
         String answer
-) {}
+) {
+    public static InterviewTurnDTO questionOnly(String questionCode, Integer sequence, String question) {
+        return new InterviewTurnDTO(questionCode, sequence, question, null);
+    }
+
+    public InterviewTurnDTO withAnswer(String answer) {
+        return new InterviewTurnDTO(questionCode, sequence, question, answer);
+    }
+}

--- a/src/main/java/com/weiver/interview/dto/response/InterviewWebSocketMessageResponse.java
+++ b/src/main/java/com/weiver/interview/dto/response/InterviewWebSocketMessageResponse.java
@@ -1,0 +1,79 @@
+package com.weiver.interview.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.weiver.interview.type.InterviewSessionStatus;
+
+import java.util.UUID;
+
+public record InterviewWebSocketMessageResponse(
+        String type,
+
+        @JsonProperty("interview_session_id")
+        UUID interviewSessionId,
+
+        String status,
+
+        @JsonProperty("question_code")
+        String questionCode,
+
+        Integer sequence,
+        String question,
+        String message
+) {
+    public static InterviewWebSocketMessageResponse sessionStarted(InterviewStartResponse response) {
+        return new InterviewWebSocketMessageResponse(
+                "SESSION_STARTED",
+                response.interviewSessionId(),
+                response.status(),
+                null,
+                null,
+                null,
+                "면접 세션이 시작되었습니다."
+        );
+    }
+
+    public static InterviewWebSocketMessageResponse answerAccepted(UUID interviewSessionId) {
+        return new InterviewWebSocketMessageResponse(
+                "ANSWER_ACCEPTED",
+                interviewSessionId,
+                InterviewSessionStatus.WAITING_FOR_QUESTION.name(),
+                null,
+                null,
+                null,
+                "답변이 제출되었습니다."
+        );
+    }
+
+    public static InterviewWebSocketMessageResponse questionReady(
+            UUID interviewSessionId,
+            InterviewSessionStatus status,
+            InterviewTurnDTO turn
+    ) {
+        return new InterviewWebSocketMessageResponse(
+                "QUESTION_READY",
+                interviewSessionId,
+                status.name(),
+                turn.questionCode(),
+                turn.sequence(),
+                turn.question(),
+                null
+        );
+    }
+
+    public static InterviewWebSocketMessageResponse statusChanged(
+            String type,
+            UUID interviewSessionId,
+            InterviewSessionStatus status,
+            String message
+    ) {
+        return new InterviewWebSocketMessageResponse(
+                type,
+                interviewSessionId,
+                status.name(),
+                null,
+                null,
+                null,
+                message
+        );
+    }
+}

--- a/src/main/java/com/weiver/interview/event/dto/InterviewQuestionGeneratedData.java
+++ b/src/main/java/com/weiver/interview/event/dto/InterviewQuestionGeneratedData.java
@@ -1,0 +1,20 @@
+package com.weiver.interview.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public record InterviewQuestionGeneratedData(
+        @JsonProperty("applicant_id")
+        Long applicantId,
+
+        @JsonProperty("interview_session_id")
+        UUID interviewSessionId,
+
+        @JsonProperty("next_question_code")
+        String nextQuestionCode,
+
+        Integer sequence,
+        String question
+) {
+}

--- a/src/main/java/com/weiver/interview/event/dto/InterviewQuestionRequestedData.java
+++ b/src/main/java/com/weiver/interview/event/dto/InterviewQuestionRequestedData.java
@@ -1,0 +1,32 @@
+package com.weiver.interview.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public record InterviewQuestionRequestedData(
+        @JsonProperty("applicant_id")
+        Long applicantId,
+
+        @JsonProperty("applicant_name")
+        String applicantName,
+
+        @JsonProperty("interview_session_id")
+        UUID interviewSessionId,
+
+        @JsonProperty("last_question_code")
+        String lastQuestionCode,
+
+        Integer sequence,
+        String job,
+        String role,
+
+        @JsonProperty("last_interview")
+        LastInterviewData lastInterview
+) {
+    public record LastInterviewData(
+            String question,
+            String answer
+    ) {
+    }
+}

--- a/src/main/java/com/weiver/interview/event/dto/InterviewReportCompletedData.java
+++ b/src/main/java/com/weiver/interview/event/dto/InterviewReportCompletedData.java
@@ -1,0 +1,27 @@
+package com.weiver.interview.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record InterviewReportCompletedData(
+        @JsonProperty("applicant_id")
+        Long applicantId,
+
+        @JsonProperty("interview_session_id")
+        UUID interviewSessionId,
+
+        @JsonProperty("applicant_name")
+        String applicantName,
+
+        @JsonProperty("skill_tags")
+        List<String> skillTags,
+
+        @JsonProperty("user_provided_tags")
+        List<String> userProvidedTags,
+
+        Map<String, Object> evaluation
+) {
+}

--- a/src/main/java/com/weiver/interview/event/dto/InterviewReportCompletedData.java
+++ b/src/main/java/com/weiver/interview/event/dto/InterviewReportCompletedData.java
@@ -6,6 +6,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * AI 최종 평가 결과 이벤트 payload.
+ *
+ * evaluation은 권장 형식인 nested map을 우선 지원한다.
+ * - skill_analysis: 기술핏 상세 분석
+ * - culture_analysis: 컬처핏 상세 분석
+ *
+ * 전환기 호환을 위해 criteria_summary 등 flat skill analysis map도 수용한다.
+ */
 public record InterviewReportCompletedData(
         @JsonProperty("applicant_id")
         Long applicantId,

--- a/src/main/java/com/weiver/interview/event/dto/InterviewReportRequestedData.java
+++ b/src/main/java/com/weiver/interview/event/dto/InterviewReportRequestedData.java
@@ -1,0 +1,14 @@
+package com.weiver.interview.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public record InterviewReportRequestedData(
+        @JsonProperty("applicant_id")
+        Long applicantId,
+
+        @JsonProperty("interview_session_id")
+        UUID interviewSessionId
+) {
+}

--- a/src/main/java/com/weiver/interview/event/dto/InterviewTranscriptSaveRequestedData.java
+++ b/src/main/java/com/weiver/interview/event/dto/InterviewTranscriptSaveRequestedData.java
@@ -1,0 +1,31 @@
+package com.weiver.interview.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InterviewTranscriptSaveRequestedData(
+        @JsonProperty("applicant_id")
+        Long applicantId,
+
+        @JsonProperty("interview_session_id")
+        UUID interviewSessionId,
+
+        @JsonProperty("skill_interview")
+        TranscriptSectionData skillInterview,
+
+        @JsonProperty("culture_interview")
+        TranscriptSectionData cultureInterview
+) {
+    public record TranscriptSectionData(
+            List<TranscriptTurnData> turns
+    ) {
+    }
+
+    public record TranscriptTurnData(
+            String question,
+            String answer
+    ) {
+    }
+}

--- a/src/main/java/com/weiver/interview/event/dto/InterviewTranscriptSavedData.java
+++ b/src/main/java/com/weiver/interview/event/dto/InterviewTranscriptSavedData.java
@@ -1,0 +1,16 @@
+package com.weiver.interview.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public record InterviewTranscriptSavedData(
+        @JsonProperty("applicant_id")
+        Long applicantId,
+
+        @JsonProperty("interview_session_id")
+        UUID interviewSessionId,
+
+        Boolean saved
+) {
+}

--- a/src/main/java/com/weiver/interview/event/handler/InterviewQuestionGeneratedHandler.java
+++ b/src/main/java/com/weiver/interview/event/handler/InterviewQuestionGeneratedHandler.java
@@ -1,0 +1,34 @@
+package com.weiver.interview.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.global.event.consumer.DomainEventHandler;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.interview.event.dto.InterviewQuestionGeneratedData;
+import com.weiver.interview.service.InterviewFlowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InterviewQuestionGeneratedHandler implements DomainEventHandler {
+
+    private final ObjectMapper objectMapper;
+    private final InterviewFlowService interviewFlowService;
+
+    @Override
+    public EventType support() {
+        return EventType.INTERVIEW_QUESTION_GENERATED;
+    }
+
+    @Override
+    public void handle(EventEnvelope<JsonNode> envelope) {
+        // AI 질문 생성 완료 이벤트를 서비스의 면접 상태 전이 로직으로 위임한다.
+        InterviewQuestionGeneratedData data = objectMapper.convertValue(
+                envelope.data(),
+                InterviewQuestionGeneratedData.class
+        );
+        interviewFlowService.handleQuestionGenerated(data);
+    }
+}

--- a/src/main/java/com/weiver/interview/event/handler/InterviewReportCompletedHandler.java
+++ b/src/main/java/com/weiver/interview/event/handler/InterviewReportCompletedHandler.java
@@ -1,0 +1,34 @@
+package com.weiver.interview.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.global.event.consumer.DomainEventHandler;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.interview.event.dto.InterviewReportCompletedData;
+import com.weiver.interview.service.InterviewFlowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InterviewReportCompletedHandler implements DomainEventHandler {
+
+    private final ObjectMapper objectMapper;
+    private final InterviewFlowService interviewFlowService;
+
+    @Override
+    public EventType support() {
+        return EventType.INTERVIEW_REPORT_COMPLETED;
+    }
+
+    @Override
+    public void handle(EventEnvelope<JsonNode> envelope) {
+        // AI 최종 평가 완료 이벤트를 서비스의 리포트 upsert 로직으로 위임한다.
+        InterviewReportCompletedData data = objectMapper.convertValue(
+                envelope.data(),
+                InterviewReportCompletedData.class
+        );
+        interviewFlowService.handleReportCompleted(data);
+    }
+}

--- a/src/main/java/com/weiver/interview/event/handler/InterviewTranscriptSavedHandler.java
+++ b/src/main/java/com/weiver/interview/event/handler/InterviewTranscriptSavedHandler.java
@@ -1,0 +1,34 @@
+package com.weiver.interview.event.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weiver.global.event.consumer.DomainEventHandler;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.interview.event.dto.InterviewTranscriptSavedData;
+import com.weiver.interview.service.InterviewFlowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InterviewTranscriptSavedHandler implements DomainEventHandler {
+
+    private final ObjectMapper objectMapper;
+    private final InterviewFlowService interviewFlowService;
+
+    @Override
+    public EventType support() {
+        return EventType.INTERVIEW_TRANSCRIPT_SAVED;
+    }
+
+    @Override
+    public void handle(EventEnvelope<JsonNode> envelope) {
+        // AI transcript 저장 완료 이벤트를 서비스의 후속 report 요청 로직으로 위임한다.
+        InterviewTranscriptSavedData data = objectMapper.convertValue(
+                envelope.data(),
+                InterviewTranscriptSavedData.class
+        );
+        interviewFlowService.handleTranscriptSaved(data);
+    }
+}

--- a/src/main/java/com/weiver/interview/service/InterviewFlowService.java
+++ b/src/main/java/com/weiver/interview/service/InterviewFlowService.java
@@ -93,6 +93,7 @@ public class InterviewFlowService {
             throw new BusinessException(ErrorCode.INTERVIEW_ALREADY_COMPLETED);
         }
 
+        boolean alreadyWaitingForQuestion = session.getSessionStatus() == InterviewSessionStatus.WAITING_FOR_QUESTION;
         InterviewTurnDTO answeredTurn = session.updateAnswer(
                 request.questionCode(),
                 request.sequence(),
@@ -100,6 +101,10 @@ public class InterviewFlowService {
         );
         if (answeredTurn == null) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "답변 대상 질문을 찾을 수 없습니다.");
+        }
+
+        if (alreadyWaitingForQuestion) {
+            return InterviewWebSocketMessageResponse.answerAccepted(session.getInterviewSessionId());
         }
 
         session.updateStatus(InterviewSessionStatus.WAITING_FOR_QUESTION);
@@ -164,6 +169,9 @@ public class InterviewFlowService {
         if (isTranscriptAlreadyProcessed(session.getSessionStatus())) {
             return;
         }
+        if (session.getSessionStatus() != InterviewSessionStatus.TRANSCRIPT_SAVE_REQUESTED) {
+            throw new NonRetryableEventException("interview transcript saved event is out of order");
+        }
         if (!Boolean.TRUE.equals(data.saved())) {
             throw new NonRetryableEventException("interview transcript was not saved");
         }
@@ -190,6 +198,11 @@ public class InterviewFlowService {
 
         InterviewSession session = getSession(data.interviewSessionId());
         validateEventApplicant(session, data.applicantId());
+
+        if (session.getSessionStatus() != InterviewSessionStatus.REPORT_REQUESTED
+                && session.getSessionStatus() != InterviewSessionStatus.REPORT_COMPLETED) {
+            throw new NonRetryableEventException("interview report completed event is out of order");
+        }
 
         Applicant applicant = applicantRepository.findById(data.applicantId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
@@ -382,6 +395,7 @@ public class InterviewFlowService {
     }
 
     private ReportAnalysis resolveAnalysis(Map<String, Object> evaluation) {
+        // AI 서버 전환기 호환을 위해 nested(skill_analysis/culture_analysis)와 flat skill map을 모두 수용한다.
         Map<String, Object> skillAnalysis = mapValue(evaluation.get("skill_analysis"));
         Map<String, Object> cultureAnalysis = mapValue(evaluation.get("culture_analysis"));
 

--- a/src/main/java/com/weiver/interview/service/InterviewFlowService.java
+++ b/src/main/java/com/weiver/interview/service/InterviewFlowService.java
@@ -1,0 +1,475 @@
+package com.weiver.interview.service;
+
+import com.weiver.analysis.domain.DetailAnalysisReport;
+import com.weiver.analysis.domain.TechnicalSkillReport;
+import com.weiver.analysis.repository.DetailAnalysisReportRepository;
+import com.weiver.analysis.repository.TechnicalSkillReportRepository;
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.NonRetryableEventException;
+import com.weiver.global.event.publisher.DomainEventPublisher;
+import com.weiver.global.event.util.EventIds;
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import com.weiver.interview.domain.InterviewSession;
+import com.weiver.interview.dto.request.InterviewAnswerSubmitRequest;
+import com.weiver.interview.dto.request.InterviewStartRequest;
+import com.weiver.interview.dto.response.InterviewStartResponse;
+import com.weiver.interview.dto.response.InterviewTurnDTO;
+import com.weiver.interview.dto.response.InterviewWebSocketMessageResponse;
+import com.weiver.interview.event.dto.InterviewQuestionGeneratedData;
+import com.weiver.interview.event.dto.InterviewQuestionRequestedData;
+import com.weiver.interview.event.dto.InterviewReportCompletedData;
+import com.weiver.interview.event.dto.InterviewReportRequestedData;
+import com.weiver.interview.event.dto.InterviewTranscriptSaveRequestedData;
+import com.weiver.interview.event.dto.InterviewTranscriptSavedData;
+import com.weiver.interview.repository.InterviewSessionRepository;
+import com.weiver.interview.type.InterviewSessionStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class InterviewFlowService {
+
+    private static final String SKILL_QUESTION_PREFIX = "S_";
+    private static final String CULTURE_QUESTION_PREFIX = "C_";
+    private static final String END_QUESTION_PREFIX = "E_";
+
+    private final ApplicantRepository applicantRepository;
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final TechnicalSkillReportRepository technicalSkillReportRepository;
+    private final DetailAnalysisReportRepository detailAnalysisReportRepository;
+    private final DomainEventPublisher domainEventPublisher;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * 새 면접 세션을 만들고 첫 질문 생성 요청 이벤트를 발행한다.
+     */
+    public InterviewStartResponse startInterview(String applicantPublicId, InterviewStartRequest request) {
+        Applicant applicant = applicantRepository.findByPublicId(applicantPublicId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        InterviewSession session = InterviewSession.builder()
+                .applicant(applicant)
+                .quarter(currentQuarter())
+                .sessionStatus(InterviewSessionStatus.STARTED)
+                .build();
+
+        interviewSessionRepository.save(session);
+        session.updateStatus(InterviewSessionStatus.WAITING_FOR_QUESTION);
+        publishQuestionRequested(session, null, 1);
+
+        return new InterviewStartResponse(
+                session.getInterviewSessionId(),
+                session.getSessionStatus().name()
+        );
+    }
+
+    /**
+     * 지원자 답변을 기존 질문 turn에 반영하고 다음 질문 생성 요청 이벤트를 발행한다.
+     */
+    public InterviewWebSocketMessageResponse submitAnswer(
+            UUID interviewSessionId,
+            String applicantPublicId,
+            InterviewAnswerSubmitRequest request
+    ) {
+        InterviewSession session = getSessionForApplicant(interviewSessionId, applicantPublicId);
+        if (isAnswerClosed(session.getSessionStatus())) {
+            throw new BusinessException(ErrorCode.INTERVIEW_ALREADY_COMPLETED);
+        }
+
+        InterviewTurnDTO answeredTurn = session.updateAnswer(
+                request.questionCode(),
+                request.sequence(),
+                request.answer()
+        );
+        if (answeredTurn == null) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "답변 대상 질문을 찾을 수 없습니다.");
+        }
+
+        session.updateStatus(InterviewSessionStatus.WAITING_FOR_QUESTION);
+        publishQuestionRequested(session, answeredTurn, answeredTurn.sequence() + 1);
+        return InterviewWebSocketMessageResponse.answerAccepted(session.getInterviewSessionId());
+    }
+
+    /**
+     * AI가 생성한 질문을 transcript에 멱등 append하고, 종료 질문이면 transcript 저장 요청으로 이어간다.
+     */
+    public void handleQuestionGenerated(InterviewQuestionGeneratedData data) {
+        validateQuestionGenerated(data);
+
+        InterviewSession session = getSession(data.interviewSessionId());
+        validateEventApplicant(session, data.applicantId());
+
+        boolean appended = session.appendQuestion(
+                data.nextQuestionCode(),
+                data.sequence(),
+                data.question()
+        );
+        if (!appended) {
+            return;
+        }
+
+        if (isEndQuestion(data.nextQuestionCode())) {
+            session.updateStatus(InterviewSessionStatus.FINISHED);
+            publishTranscriptSaveRequested(session);
+            session.updateStatus(InterviewSessionStatus.TRANSCRIPT_SAVE_REQUESTED);
+            sendInterviewMessage(
+                    session,
+                    InterviewWebSocketMessageResponse.statusChanged(
+                            "TRANSCRIPT_SAVE_REQUESTED",
+                            session.getInterviewSessionId(),
+                            session.getSessionStatus(),
+                            "면접이 종료되어 transcript 저장을 요청했습니다."
+                    )
+            );
+            return;
+        }
+
+        session.updateStatus(InterviewSessionStatus.QUESTION_READY);
+        sendInterviewMessage(
+                session,
+                InterviewWebSocketMessageResponse.questionReady(
+                        session.getInterviewSessionId(),
+                        session.getSessionStatus(),
+                        session.getTranscript().get(session.getTranscript().size() - 1)
+                )
+        );
+    }
+
+    /**
+     * AI 서버의 transcript 저장 완료를 반영하고 최종 리포트 생성 요청 이벤트를 발행한다.
+     */
+    public void handleTranscriptSaved(InterviewTranscriptSavedData data) {
+        validateTranscriptSaved(data);
+
+        InterviewSession session = getSession(data.interviewSessionId());
+        validateEventApplicant(session, data.applicantId());
+
+        if (isTranscriptAlreadyProcessed(session.getSessionStatus())) {
+            return;
+        }
+        if (!Boolean.TRUE.equals(data.saved())) {
+            throw new NonRetryableEventException("interview transcript was not saved");
+        }
+
+        session.updateStatus(InterviewSessionStatus.TRANSCRIPT_SAVED);
+        publishReportRequested(session);
+        session.updateStatus(InterviewSessionStatus.REPORT_REQUESTED);
+        sendInterviewMessage(
+                session,
+                InterviewWebSocketMessageResponse.statusChanged(
+                        "REPORT_REQUESTED",
+                        session.getInterviewSessionId(),
+                        session.getSessionStatus(),
+                        "transcript 저장이 완료되어 최종 리포트 생성을 요청했습니다."
+                )
+        );
+    }
+
+    /**
+     * AI 최종 평가 결과를 interview_session_id 기준으로 저장하거나 갱신한다.
+     */
+    public void handleReportCompleted(InterviewReportCompletedData data) {
+        validateReportCompleted(data);
+
+        InterviewSession session = getSession(data.interviewSessionId());
+        validateEventApplicant(session, data.applicantId());
+
+        Applicant applicant = applicantRepository.findById(data.applicantId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        ReportAnalysis analysis = resolveAnalysis(data.evaluation());
+        detailAnalysisReportRepository.findByInterviewSession_InterviewSessionId(data.interviewSessionId())
+                .ifPresentOrElse(
+                        report -> report.updateAnalysis(analysis.skillAnalysis(), analysis.cultureAnalysis()),
+                        () -> detailAnalysisReportRepository.save(DetailAnalysisReport.builder()
+                                .applicant(applicant)
+                                .interviewSession(session)
+                                .skillAnalysis(analysis.skillAnalysis())
+                                .cultureAnalysis(analysis.cultureAnalysis())
+                                .build())
+                );
+
+        session.updateStatus(InterviewSessionStatus.REPORT_COMPLETED);
+        sendInterviewMessage(
+                session,
+                InterviewWebSocketMessageResponse.statusChanged(
+                        "REPORT_COMPLETED",
+                        session.getInterviewSessionId(),
+                        session.getSessionStatus(),
+                        "최종 리포트 생성이 완료되었습니다."
+                )
+        );
+    }
+
+    /**
+     * 다음 질문 생성 요청 payload를 현재 세션 상태와 마지막 답변 기준으로 구성한다.
+     */
+    private void publishQuestionRequested(InterviewSession session, InterviewTurnDTO lastTurn, Integer nextSequence) {
+        Applicant applicant = session.getApplicant();
+        TechnicalSkillReport technicalSkillReport = technicalSkillReportRepository.findByApplicant(applicant)
+                .orElse(null);
+
+        InterviewQuestionRequestedData data = new InterviewQuestionRequestedData(
+                applicant.getApplicantId(),
+                applicant.getName(),
+                session.getInterviewSessionId(),
+                lastTurn != null ? lastTurn.questionCode() : null,
+                nextSequence,
+                technicalSkillReport != null ? technicalSkillReport.getJob() : null,
+                technicalSkillReport != null ? technicalSkillReport.getRole() : null,
+                new InterviewQuestionRequestedData.LastInterviewData(
+                        lastTurn != null ? lastTurn.question() : null,
+                        lastTurn != null ? lastTurn.answer() : null
+                )
+        );
+
+        publishAfterCommit(EventEnvelope.request(
+                EventType.INTERVIEW_QUESTION_REQUESTED,
+                data,
+                EventIds.newEventId()
+        ));
+    }
+
+    /**
+     * 종료된 면접 transcript를 기술/컬처 섹션으로 나누어 AI 서버 저장 요청 이벤트로 발행한다.
+     */
+    private void publishTranscriptSaveRequested(InterviewSession session) {
+        InterviewTranscriptSaveRequestedData data = new InterviewTranscriptSaveRequestedData(
+                session.getApplicant().getApplicantId(),
+                session.getInterviewSessionId(),
+                new InterviewTranscriptSaveRequestedData.TranscriptSectionData(toTranscriptTurns(session, SKILL_QUESTION_PREFIX)),
+                new InterviewTranscriptSaveRequestedData.TranscriptSectionData(toTranscriptTurns(session, CULTURE_QUESTION_PREFIX))
+        );
+
+        publishAfterCommit(EventEnvelope.request(
+                EventType.INTERVIEW_TRANSCRIPT_SAVE_REQUESTED,
+                data,
+                EventIds.newEventId()
+        ));
+    }
+
+    /**
+     * 저장된 transcript를 기반으로 AI 서버에 최종 리포트 생성을 요청한다.
+     */
+    private void publishReportRequested(InterviewSession session) {
+        InterviewReportRequestedData data = new InterviewReportRequestedData(
+                session.getApplicant().getApplicantId(),
+                session.getInterviewSessionId()
+        );
+
+        publishAfterCommit(EventEnvelope.request(
+                EventType.INTERVIEW_REPORT_REQUESTED,
+                data,
+                EventIds.newEventId()
+        ));
+    }
+
+    /**
+     * 면접 진행 상태를 연결된 지원자 WebSocket 구독 채널로 전송한다.
+     */
+    private void sendInterviewMessage(InterviewSession session, InterviewWebSocketMessageResponse response) {
+        String applicantPublicId = session.getApplicant().getPublicId();
+        Runnable sender = () -> messagingTemplate.convertAndSendToUser(
+                applicantPublicId,
+                "/queue/interviews",
+                response
+        );
+
+        if (!TransactionSynchronizationManager.isActualTransactionActive()
+                || !TransactionSynchronizationManager.isSynchronizationActive()) {
+            sender.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                sender.run();
+            }
+        });
+    }
+
+    private List<InterviewTranscriptSaveRequestedData.TranscriptTurnData> toTranscriptTurns(
+            InterviewSession session,
+            String questionPrefix
+    ) {
+        return session.getTranscript().stream()
+                .filter(Objects::nonNull)
+                .filter(turn -> turn.questionCode() != null && turn.questionCode().startsWith(questionPrefix))
+                .map(turn -> new InterviewTranscriptSaveRequestedData.TranscriptTurnData(
+                        turn.question(),
+                        turn.answer()
+                ))
+                .toList();
+    }
+
+    private InterviewSession getSession(UUID interviewSessionId) {
+        return interviewSessionRepository.findByInterviewSessionId(interviewSessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERVIEW_SESSION_NOT_FOUND));
+    }
+
+    private InterviewSession getSessionForApplicant(UUID interviewSessionId, String applicantPublicId) {
+        InterviewSession session = getSession(interviewSessionId);
+        if (!Objects.equals(session.getApplicant().getPublicId(), applicantPublicId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return session;
+    }
+
+    private void validateEventApplicant(InterviewSession session, Long applicantId) {
+        if (!Objects.equals(session.getApplicant().getApplicantId(), applicantId)) {
+            throw new NonRetryableEventException("applicant_id does not match interview_session_id");
+        }
+    }
+
+    private void validateQuestionGenerated(InterviewQuestionGeneratedData data) {
+        if (data.applicantId() == null) {
+            throw new NonRetryableEventException("applicant_id is required");
+        }
+        if (data.interviewSessionId() == null) {
+            throw new NonRetryableEventException("interview_session_id is required");
+        }
+        if (data.nextQuestionCode() == null || data.nextQuestionCode().isBlank()) {
+            throw new NonRetryableEventException("next_question_code is required");
+        }
+        if (data.sequence() == null) {
+            throw new NonRetryableEventException("sequence is required");
+        }
+        if (data.question() == null || data.question().isBlank()) {
+            throw new NonRetryableEventException("question is required");
+        }
+    }
+
+    private void validateTranscriptSaved(InterviewTranscriptSavedData data) {
+        if (data.applicantId() == null) {
+            throw new NonRetryableEventException("applicant_id is required");
+        }
+        if (data.interviewSessionId() == null) {
+            throw new NonRetryableEventException("interview_session_id is required");
+        }
+        if (data.saved() == null) {
+            throw new NonRetryableEventException("saved is required");
+        }
+    }
+
+    private void validateReportCompleted(InterviewReportCompletedData data) {
+        if (data.applicantId() == null) {
+            throw new NonRetryableEventException("applicant_id is required");
+        }
+        if (data.interviewSessionId() == null) {
+            throw new NonRetryableEventException("interview_session_id is required");
+        }
+        if (data.evaluation() == null) {
+            throw new NonRetryableEventException("evaluation is required");
+        }
+    }
+
+    private ReportAnalysis resolveAnalysis(Map<String, Object> evaluation) {
+        Map<String, Object> skillAnalysis = mapValue(evaluation.get("skill_analysis"));
+        Map<String, Object> cultureAnalysis = mapValue(evaluation.get("culture_analysis"));
+
+        if (skillAnalysis == null && hasSkillAnalysisKeys(evaluation)) {
+            skillAnalysis = evaluation;
+        }
+        if (cultureAnalysis == null && hasCultureAnalysisKeys(evaluation)) {
+            cultureAnalysis = evaluation;
+        }
+        if (skillAnalysis == null && cultureAnalysis == null) {
+            skillAnalysis = evaluation;
+        }
+
+        return new ReportAnalysis(
+                skillAnalysis != null ? skillAnalysis : Map.of(),
+                cultureAnalysis != null ? cultureAnalysis : Map.of()
+        );
+    }
+
+    private Map<String, Object> mapValue(Object value) {
+        if (!(value instanceof Map<?, ?> source)) {
+            return null;
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        source.forEach((key, mapValue) -> {
+            if (key != null) {
+                result.put(key.toString(), mapValue);
+            }
+        });
+        return result;
+    }
+
+    private boolean hasSkillAnalysisKeys(Map<String, Object> evaluation) {
+        return evaluation.containsKey("criteria_summary");
+    }
+
+    private boolean hasCultureAnalysisKeys(Map<String, Object> evaluation) {
+        return evaluation.containsKey("culture_axis")
+                || evaluation.containsKey("extracted_culturefit");
+    }
+
+    private boolean isAnswerClosed(InterviewSessionStatus status) {
+        return status == InterviewSessionStatus.FINISHED
+                || status == InterviewSessionStatus.TRANSCRIPT_SAVE_REQUESTED
+                || status == InterviewSessionStatus.TRANSCRIPT_SAVED
+                || status == InterviewSessionStatus.REPORT_REQUESTED
+                || status == InterviewSessionStatus.REPORT_COMPLETED
+                || status == InterviewSessionStatus.FAILED;
+    }
+
+    private boolean isTranscriptAlreadyProcessed(InterviewSessionStatus status) {
+        return status == InterviewSessionStatus.TRANSCRIPT_SAVED
+                || status == InterviewSessionStatus.REPORT_REQUESTED
+                || status == InterviewSessionStatus.REPORT_COMPLETED;
+    }
+
+    private boolean isEndQuestion(String questionCode) {
+        return questionCode != null && questionCode.startsWith(END_QUESTION_PREFIX);
+    }
+
+    private String currentQuarter() {
+        LocalDate today = LocalDate.now();
+        int quarter = ((today.getMonthValue() - 1) / 3) + 1;
+        return today.getYear() + "Q" + quarter;
+    }
+
+    /**
+     * DB 변경이 커밋된 뒤 RabbitMQ 이벤트를 발행해 DB 상태와 메시지 순서를 맞춘다.
+     */
+    private void publishAfterCommit(EventEnvelope<?> envelope) {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()
+                || !TransactionSynchronizationManager.isSynchronizationActive()) {
+            domainEventPublisher.publish(envelope);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                domainEventPublisher.publish(envelope);
+            }
+        });
+    }
+
+    private record ReportAnalysis(
+            Map<String, Object> skillAnalysis,
+            Map<String, Object> cultureAnalysis
+    ) {
+    }
+}

--- a/src/main/java/com/weiver/interview/websocket/InterviewWebSocketController.java
+++ b/src/main/java/com/weiver/interview/websocket/InterviewWebSocketController.java
@@ -1,0 +1,54 @@
+package com.weiver.interview.websocket;
+
+import com.weiver.global.exception.BusinessException;
+import com.weiver.global.exception.ErrorCode;
+import com.weiver.interview.dto.request.InterviewAnswerSubmitRequest;
+import com.weiver.interview.dto.request.InterviewStartRequest;
+import com.weiver.interview.dto.response.InterviewStartResponse;
+import com.weiver.interview.dto.response.InterviewWebSocketMessageResponse;
+import com.weiver.interview.service.InterviewFlowService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
+
+import java.security.Principal;
+import java.util.UUID;
+
+@Controller
+@Validated
+@RequiredArgsConstructor
+public class InterviewWebSocketController {
+
+    private final InterviewFlowService interviewFlowService;
+
+    @MessageMapping("/interviews/start")
+    @SendToUser("/queue/interviews")
+    public InterviewWebSocketMessageResponse startInterview(
+            InterviewStartRequest request,
+            Principal principal
+    ) {
+        InterviewStartResponse response = interviewFlowService.startInterview(publicId(principal), request);
+        return InterviewWebSocketMessageResponse.sessionStarted(response);
+    }
+
+    @MessageMapping("/interviews/{interviewSessionId}/answers")
+    @SendToUser("/queue/interviews")
+    public InterviewWebSocketMessageResponse submitAnswer(
+            @DestinationVariable UUID interviewSessionId,
+            @Valid InterviewAnswerSubmitRequest request,
+            Principal principal
+    ) {
+        return interviewFlowService.submitAnswer(interviewSessionId, publicId(principal), request);
+    }
+
+    private String publicId(Principal principal) {
+        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        return principal.getName();
+    }
+}

--- a/src/test/java/com/weiver/interview/service/InterviewFlowServiceTest.java
+++ b/src/test/java/com/weiver/interview/service/InterviewFlowServiceTest.java
@@ -8,7 +8,9 @@ import com.weiver.applicant.domain.Applicant;
 import com.weiver.applicant.repository.ApplicantRepository;
 import com.weiver.global.event.dto.EventEnvelope;
 import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.exception.NonRetryableEventException;
 import com.weiver.global.event.publisher.DomainEventPublisher;
+import com.weiver.global.exception.BusinessException;
 import com.weiver.interview.domain.InterviewSession;
 import com.weiver.interview.dto.request.InterviewAnswerSubmitRequest;
 import com.weiver.interview.dto.request.InterviewStartRequest;
@@ -36,6 +38,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -96,6 +99,7 @@ class InterviewFlowServiceTest {
         assertThat(data.sequence()).isEqualTo(1);
         assertThat(data.lastQuestionCode()).isNull();
         assertThat(data.lastInterview().question()).isNull();
+        assertThat(data.lastInterview().answer()).isNull();
         assertThat(data.job()).isEqualTo("DEVELOPER");
         assertThat(data.role()).isEqualTo("BACKEND");
     }
@@ -149,6 +153,49 @@ class InterviewFlowServiceTest {
         assertThat(data.lastQuestionCode()).isEqualTo("S_01_00");
         assertThat(data.lastInterview().question()).isEqualTo("첫 질문");
         assertThat(data.lastInterview().answer()).isEqualTo("첫 답변");
+    }
+
+    @Test
+    @DisplayName("답변 제출 재시도 중 이미 다음 질문 대기 상태면 다음 질문 요청 이벤트를 재발행하지 않는다")
+    void submitAnswer_DoesNotRepublishQuestionRequestWhenAlreadyWaiting() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.WAITING_FOR_QUESTION,
+                List.of(new InterviewTurnDTO("S_01_00", 1, "첫 질문", "첫 답변")));
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+
+        interviewFlowService.submitAnswer(
+                sessionId,
+                APPLICANT_PUBLIC_ID,
+                new InterviewAnswerSubmitRequest("S_01_00", 1, "수정 답변")
+        );
+
+        assertThat(session.getTranscript().get(0).answer()).isEqualTo("수정 답변");
+        assertThat(session.getSessionStatus()).isEqualTo(InterviewSessionStatus.WAITING_FOR_QUESTION);
+        verifyNoInteractions(domainEventPublisher);
+    }
+
+    @Test
+    @DisplayName("답변 제출 대상은 questionCode와 sequence가 모두 일치해야 한다")
+    void submitAnswer_RequiresExactQuestionCodeAndSequenceMatch() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.QUESTION_READY,
+                List.of(InterviewTurnDTO.questionOnly("S_01_00", 1, "첫 질문")));
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> interviewFlowService.submitAnswer(
+                sessionId,
+                APPLICANT_PUBLIC_ID,
+                new InterviewAnswerSubmitRequest("S_01_00", 2, "잘못된 답변")
+        ))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("답변 대상 질문을 찾을 수 없습니다.");
+
+        assertThat(session.getTranscript().get(0).answer()).isNull();
+        verifyNoInteractions(domainEventPublisher);
     }
 
     @Test
@@ -231,8 +278,26 @@ class InterviewFlowServiceTest {
     }
 
     @Test
-    @DisplayName("report 완료 이벤트 수신 시 DetailAnalysisReport를 interview_session_id 기준으로 insert한다")
-    void handleReportCompleted_InsertsDetailAnalysisReport() {
+    @DisplayName("transcript 저장 완료 이벤트는 transcript 저장 요청 상태에서만 처리한다")
+    void handleTranscriptSaved_RejectsOutOfOrderEvent() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.QUESTION_READY, List.of());
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> interviewFlowService.handleTranscriptSaved(
+                new InterviewTranscriptSavedData(1L, sessionId, true)
+        ))
+                .isInstanceOf(NonRetryableEventException.class)
+                .hasMessage("interview transcript saved event is out of order");
+
+        verifyNoInteractions(domainEventPublisher);
+    }
+
+    @Test
+    @DisplayName("nested evaluation map 수신 시 DetailAnalysisReport를 interview_session_id 기준으로 insert한다")
+    void handleReportCompleted_InsertsDetailAnalysisReportWithNestedEvaluation() {
         Applicant applicant = applicant();
         UUID sessionId = UUID.randomUUID();
         InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.REPORT_REQUESTED, List.of());
@@ -264,8 +329,8 @@ class InterviewFlowServiceTest {
     }
 
     @Test
-    @DisplayName("report 완료 이벤트가 중복 수신되면 기존 DetailAnalysisReport를 update한다")
-    void handleReportCompleted_UpdatesExistingDetailAnalysisReport() {
+    @DisplayName("flat skill evaluation map 수신 시 전체 evaluation을 skillAnalysis로 update한다")
+    void handleReportCompleted_UpdatesExistingDetailAnalysisReportWithFlatSkillEvaluation() {
         Applicant applicant = applicant();
         UUID sessionId = UUID.randomUUID();
         InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.REPORT_COMPLETED, List.of());
@@ -293,6 +358,29 @@ class InterviewFlowServiceTest {
         verify(detailAnalysisReportRepository, never()).save(any());
         assertThat(existing.getSkillAnalysis()).isEqualTo(evaluation);
         assertThat(existing.getCultureAnalysis()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("report 완료 이벤트는 report 요청 이후 상태에서만 처리한다")
+    void handleReportCompleted_RejectsOutOfOrderEvent() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.TRANSCRIPT_SAVE_REQUESTED, List.of());
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> interviewFlowService.handleReportCompleted(new InterviewReportCompletedData(
+                1L,
+                sessionId,
+                "홍길동",
+                List.of(),
+                List.of(),
+                Map.of("criteria_summary", Map.of())
+        )))
+                .isInstanceOf(NonRetryableEventException.class)
+                .hasMessage("interview report completed event is out of order");
+
+        verifyNoInteractions(detailAnalysisReportRepository);
     }
 
     private Applicant applicant() {

--- a/src/test/java/com/weiver/interview/service/InterviewFlowServiceTest.java
+++ b/src/test/java/com/weiver/interview/service/InterviewFlowServiceTest.java
@@ -1,0 +1,320 @@
+package com.weiver.interview.service;
+
+import com.weiver.analysis.domain.DetailAnalysisReport;
+import com.weiver.analysis.domain.TechnicalSkillReport;
+import com.weiver.analysis.repository.DetailAnalysisReportRepository;
+import com.weiver.analysis.repository.TechnicalSkillReportRepository;
+import com.weiver.applicant.domain.Applicant;
+import com.weiver.applicant.repository.ApplicantRepository;
+import com.weiver.global.event.dto.EventEnvelope;
+import com.weiver.global.event.dto.EventType;
+import com.weiver.global.event.publisher.DomainEventPublisher;
+import com.weiver.interview.domain.InterviewSession;
+import com.weiver.interview.dto.request.InterviewAnswerSubmitRequest;
+import com.weiver.interview.dto.request.InterviewStartRequest;
+import com.weiver.interview.dto.response.InterviewStartResponse;
+import com.weiver.interview.dto.response.InterviewTurnDTO;
+import com.weiver.interview.event.dto.InterviewQuestionGeneratedData;
+import com.weiver.interview.event.dto.InterviewQuestionRequestedData;
+import com.weiver.interview.event.dto.InterviewReportCompletedData;
+import com.weiver.interview.event.dto.InterviewTranscriptSaveRequestedData;
+import com.weiver.interview.event.dto.InterviewTranscriptSavedData;
+import com.weiver.interview.repository.InterviewSessionRepository;
+import com.weiver.interview.type.InterviewSessionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewFlowServiceTest {
+
+    private static final String APPLICANT_PUBLIC_ID = "applicant-public-id";
+
+    @InjectMocks
+    private InterviewFlowService interviewFlowService;
+
+    @Mock private ApplicantRepository applicantRepository;
+    @Mock private InterviewSessionRepository interviewSessionRepository;
+    @Mock private TechnicalSkillReportRepository technicalSkillReportRepository;
+    @Mock private DetailAnalysisReportRepository detailAnalysisReportRepository;
+    @Mock private DomainEventPublisher domainEventPublisher;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+
+    @Test
+    @DisplayName("면접 시작 시 새 세션을 만들고 첫 질문 생성 요청 이벤트를 발행한다")
+    void startInterview_CreatesSessionAndPublishesFirstQuestionRequest() {
+        Applicant applicant = applicant();
+        TechnicalSkillReport technicalSkillReport = TechnicalSkillReport.builder()
+                .job("DEVELOPER")
+                .role("BACKEND")
+                .build();
+
+        given(applicantRepository.findByPublicId(APPLICANT_PUBLIC_ID)).willReturn(Optional.of(applicant));
+        given(technicalSkillReportRepository.findByApplicant(applicant)).willReturn(Optional.of(technicalSkillReport));
+
+        InterviewStartResponse response = interviewFlowService.startInterview(
+                APPLICANT_PUBLIC_ID,
+                new InterviewStartRequest("TECHNICAL")
+        );
+
+        ArgumentCaptor<InterviewSession> sessionCaptor = ArgumentCaptor.forClass(InterviewSession.class);
+        verify(interviewSessionRepository).save(sessionCaptor.capture());
+        InterviewSession session = sessionCaptor.getValue();
+
+        ArgumentCaptor<EventEnvelope<?>> eventCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(domainEventPublisher).publish(eventCaptor.capture());
+
+        assertThat(response.interviewSessionId()).isEqualTo(session.getInterviewSessionId());
+        assertThat(response.status()).isEqualTo(InterviewSessionStatus.WAITING_FOR_QUESTION.name());
+        assertThat(session.getSessionStatus()).isEqualTo(InterviewSessionStatus.WAITING_FOR_QUESTION);
+        assertThat(session.getTranscript()).isEmpty();
+        assertThat(session.getQuarter()).matches("\\d{4}Q[1-4]");
+
+        EventEnvelope<?> envelope = eventCaptor.getValue();
+        assertThat(envelope.eventType()).isEqualTo(EventType.INTERVIEW_QUESTION_REQUESTED);
+        InterviewQuestionRequestedData data = (InterviewQuestionRequestedData) envelope.data();
+        assertThat(data.applicantId()).isEqualTo(1L);
+        assertThat(data.interviewSessionId()).isEqualTo(session.getInterviewSessionId());
+        assertThat(data.sequence()).isEqualTo(1);
+        assertThat(data.lastQuestionCode()).isNull();
+        assertThat(data.lastInterview().question()).isNull();
+        assertThat(data.job()).isEqualTo("DEVELOPER");
+        assertThat(data.role()).isEqualTo("BACKEND");
+    }
+
+    @Test
+    @DisplayName("같은 지원자가 면접을 여러 번 시작해도 매번 다른 interview_session_id를 만든다")
+    void startInterview_AllowsMultipleSessionsForSameApplicant() {
+        Applicant applicant = applicant();
+        given(applicantRepository.findByPublicId(APPLICANT_PUBLIC_ID)).willReturn(Optional.of(applicant));
+        given(technicalSkillReportRepository.findByApplicant(applicant)).willReturn(Optional.empty());
+
+        interviewFlowService.startInterview(APPLICANT_PUBLIC_ID, new InterviewStartRequest("TECHNICAL"));
+        interviewFlowService.startInterview(APPLICANT_PUBLIC_ID, new InterviewStartRequest("TECHNICAL"));
+
+        ArgumentCaptor<InterviewSession> sessionCaptor = ArgumentCaptor.forClass(InterviewSession.class);
+        verify(interviewSessionRepository, times(2)).save(sessionCaptor.capture());
+
+        List<InterviewSession> sessions = sessionCaptor.getAllValues();
+        assertThat(sessions.get(0).getInterviewSessionId()).isNotEqualTo(sessions.get(1).getInterviewSessionId());
+        verify(domainEventPublisher, times(2)).publish(any());
+    }
+
+    @Test
+    @DisplayName("답변 제출 시 기존 질문 turn을 overwrite하고 다음 질문 요청 이벤트를 발행한다")
+    void submitAnswer_UpdatesTurnAndPublishesNextQuestionRequest() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.QUESTION_READY,
+                List.of(InterviewTurnDTO.questionOnly("S_01_00", 1, "첫 질문")));
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+        given(technicalSkillReportRepository.findByApplicant(applicant)).willReturn(Optional.empty());
+
+        interviewFlowService.submitAnswer(
+                sessionId,
+                APPLICANT_PUBLIC_ID,
+                new InterviewAnswerSubmitRequest("S_01_00", 1, "첫 답변")
+        );
+
+        assertThat(session.getTranscript()).hasSize(1);
+        assertThat(session.getTranscript().get(0).answer()).isEqualTo("첫 답변");
+        assertThat(session.getSessionStatus()).isEqualTo(InterviewSessionStatus.WAITING_FOR_QUESTION);
+
+        ArgumentCaptor<EventEnvelope<?>> eventCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(domainEventPublisher).publish(eventCaptor.capture());
+
+        EventEnvelope<?> envelope = eventCaptor.getValue();
+        assertThat(envelope.eventType()).isEqualTo(EventType.INTERVIEW_QUESTION_REQUESTED);
+        InterviewQuestionRequestedData data = (InterviewQuestionRequestedData) envelope.data();
+        assertThat(data.sequence()).isEqualTo(2);
+        assertThat(data.lastQuestionCode()).isEqualTo("S_01_00");
+        assertThat(data.lastInterview().question()).isEqualTo("첫 질문");
+        assertThat(data.lastInterview().answer()).isEqualTo("첫 답변");
+    }
+
+    @Test
+    @DisplayName("이미 저장된 질문 생성 이벤트가 중복 수신되면 transcript에 다시 append하지 않는다")
+    void handleQuestionGenerated_IgnoresDuplicateQuestion() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.QUESTION_READY,
+                List.of(InterviewTurnDTO.questionOnly("S_01_00", 1, "첫 질문")));
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+
+        interviewFlowService.handleQuestionGenerated(new InterviewQuestionGeneratedData(
+                1L,
+                sessionId,
+                "S_01_00",
+                1,
+                "첫 질문"
+        ));
+
+        assertThat(session.getTranscript()).hasSize(1);
+        verifyNoInteractions(domainEventPublisher);
+    }
+
+    @Test
+    @DisplayName("E_ 질문이 생성되면 면접을 종료하고 transcript 저장 요청 이벤트를 발행한다")
+    void handleQuestionGenerated_PublishesTranscriptSaveRequestForEndQuestion() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.WAITING_FOR_QUESTION,
+                List.of(
+                        new InterviewTurnDTO("S_01_00", 1, "기술 질문", "기술 답변"),
+                        new InterviewTurnDTO("C_01_00", 2, "컬처 질문", "컬처 답변")
+                ));
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+
+        interviewFlowService.handleQuestionGenerated(new InterviewQuestionGeneratedData(
+                1L,
+                sessionId,
+                "E_00_00",
+                3,
+                "면접이 종료되었습니다."
+        ));
+
+        assertThat(session.getSessionStatus()).isEqualTo(InterviewSessionStatus.TRANSCRIPT_SAVE_REQUESTED);
+        assertThat(session.getTranscript()).hasSize(3);
+
+        ArgumentCaptor<EventEnvelope<?>> eventCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(domainEventPublisher).publish(eventCaptor.capture());
+
+        EventEnvelope<?> envelope = eventCaptor.getValue();
+        assertThat(envelope.eventType()).isEqualTo(EventType.INTERVIEW_TRANSCRIPT_SAVE_REQUESTED);
+        InterviewTranscriptSaveRequestedData data = (InterviewTranscriptSaveRequestedData) envelope.data();
+        assertThat(data.interviewSessionId()).isEqualTo(sessionId);
+        assertThat(data.skillInterview().turns()).hasSize(1);
+        assertThat(data.skillInterview().turns().get(0).answer()).isEqualTo("기술 답변");
+        assertThat(data.cultureInterview().turns()).hasSize(1);
+        assertThat(data.cultureInterview().turns().get(0).question()).isEqualTo("컬처 질문");
+    }
+
+    @Test
+    @DisplayName("transcript 저장 완료 이벤트 수신 시 report 요청 이벤트를 이어서 발행한다")
+    void handleTranscriptSaved_PublishesReportRequest() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.TRANSCRIPT_SAVE_REQUESTED, List.of());
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+
+        interviewFlowService.handleTranscriptSaved(new InterviewTranscriptSavedData(1L, sessionId, true));
+
+        assertThat(session.getSessionStatus()).isEqualTo(InterviewSessionStatus.REPORT_REQUESTED);
+
+        ArgumentCaptor<EventEnvelope<?>> eventCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(domainEventPublisher).publish(eventCaptor.capture());
+
+        EventEnvelope<?> envelope = eventCaptor.getValue();
+        assertThat(envelope.eventType()).isEqualTo(EventType.INTERVIEW_REPORT_REQUESTED);
+    }
+
+    @Test
+    @DisplayName("report 완료 이벤트 수신 시 DetailAnalysisReport를 interview_session_id 기준으로 insert한다")
+    void handleReportCompleted_InsertsDetailAnalysisReport() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.REPORT_REQUESTED, List.of());
+        Map<String, Object> skillAnalysis = Map.of("criteria_summary", Map.of("logic", Map.of("average_score", 4.5)));
+        Map<String, Object> cultureAnalysis = Map.of("culture_axis", Map.of("openness_to_change", 0.8));
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+        given(applicantRepository.findById(1L)).willReturn(Optional.of(applicant));
+        given(detailAnalysisReportRepository.findByInterviewSession_InterviewSessionId(sessionId)).willReturn(Optional.empty());
+
+        interviewFlowService.handleReportCompleted(new InterviewReportCompletedData(
+                1L,
+                sessionId,
+                "홍길동",
+                List.of("Java"),
+                List.of("Spring"),
+                Map.of("skill_analysis", skillAnalysis, "culture_analysis", cultureAnalysis)
+        ));
+
+        ArgumentCaptor<DetailAnalysisReport> reportCaptor = ArgumentCaptor.forClass(DetailAnalysisReport.class);
+        verify(detailAnalysisReportRepository).save(reportCaptor.capture());
+
+        DetailAnalysisReport saved = reportCaptor.getValue();
+        assertThat(saved.getApplicant()).isEqualTo(applicant);
+        assertThat(saved.getInterviewSession()).isEqualTo(session);
+        assertThat(saved.getSkillAnalysis()).isEqualTo(skillAnalysis);
+        assertThat(saved.getCultureAnalysis()).isEqualTo(cultureAnalysis);
+        assertThat(session.getSessionStatus()).isEqualTo(InterviewSessionStatus.REPORT_COMPLETED);
+    }
+
+    @Test
+    @DisplayName("report 완료 이벤트가 중복 수신되면 기존 DetailAnalysisReport를 update한다")
+    void handleReportCompleted_UpdatesExistingDetailAnalysisReport() {
+        Applicant applicant = applicant();
+        UUID sessionId = UUID.randomUUID();
+        InterviewSession session = session(sessionId, applicant, InterviewSessionStatus.REPORT_COMPLETED, List.of());
+        DetailAnalysisReport existing = DetailAnalysisReport.builder()
+                .applicant(applicant)
+                .interviewSession(session)
+                .skillAnalysis(Map.of())
+                .cultureAnalysis(Map.of())
+                .build();
+        Map<String, Object> evaluation = Map.of("criteria_summary", Map.of("logic", Map.of("average_score", 5.0)));
+
+        given(interviewSessionRepository.findByInterviewSessionId(sessionId)).willReturn(Optional.of(session));
+        given(applicantRepository.findById(1L)).willReturn(Optional.of(applicant));
+        given(detailAnalysisReportRepository.findByInterviewSession_InterviewSessionId(sessionId)).willReturn(Optional.of(existing));
+
+        interviewFlowService.handleReportCompleted(new InterviewReportCompletedData(
+                1L,
+                sessionId,
+                "홍길동",
+                List.of(),
+                List.of(),
+                evaluation
+        ));
+
+        verify(detailAnalysisReportRepository, never()).save(any());
+        assertThat(existing.getSkillAnalysis()).isEqualTo(evaluation);
+        assertThat(existing.getCultureAnalysis()).isEmpty();
+    }
+
+    private Applicant applicant() {
+        return Applicant.builder()
+                .applicantId(1L)
+                .publicId(APPLICANT_PUBLIC_ID)
+                .name("홍길동")
+                .build();
+    }
+
+    private InterviewSession session(
+            UUID sessionId,
+            Applicant applicant,
+            InterviewSessionStatus status,
+            List<InterviewTurnDTO> transcript
+    ) {
+        return InterviewSession.builder()
+                .interviewSessionId(sessionId)
+                .applicant(applicant)
+                .quarter("2026Q2")
+                .sessionStatus(status)
+                .transcript(transcript)
+                .build();
+    }
+}

--- a/src/test/java/com/weiver/interview/websocket/InterviewWebSocketControllerTest.java
+++ b/src/test/java/com/weiver/interview/websocket/InterviewWebSocketControllerTest.java
@@ -1,0 +1,64 @@
+package com.weiver.interview.websocket;
+
+import com.weiver.interview.dto.request.InterviewAnswerSubmitRequest;
+import com.weiver.interview.dto.request.InterviewStartRequest;
+import com.weiver.interview.dto.response.InterviewStartResponse;
+import com.weiver.interview.dto.response.InterviewWebSocketMessageResponse;
+import com.weiver.interview.service.InterviewFlowService;
+import com.weiver.interview.type.InterviewSessionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class InterviewWebSocketControllerTest {
+
+    private static final String APPLICANT_PUBLIC_ID = "applicant-public-id";
+
+    private final InterviewFlowService interviewFlowService = mock(InterviewFlowService.class);
+    private final InterviewWebSocketController controller = new InterviewWebSocketController(interviewFlowService);
+
+    @Test
+    @DisplayName("WebSocket 면접 시작 메시지는 지원자 publicId로 세션을 시작하고 SESSION_STARTED 응답을 반환한다")
+    void startInterview_ReturnsSessionStartedMessage() {
+        UUID sessionId = UUID.randomUUID();
+        InterviewStartRequest request = new InterviewStartRequest("TECHNICAL");
+
+        given(interviewFlowService.startInterview(APPLICANT_PUBLIC_ID, request))
+                .willReturn(new InterviewStartResponse(sessionId, InterviewSessionStatus.WAITING_FOR_QUESTION.name()));
+
+        InterviewWebSocketMessageResponse response = controller.startInterview(request, principal());
+
+        assertThat(response.type()).isEqualTo("SESSION_STARTED");
+        assertThat(response.interviewSessionId()).isEqualTo(sessionId);
+        assertThat(response.status()).isEqualTo("WAITING_FOR_QUESTION");
+        verify(interviewFlowService).startInterview(APPLICANT_PUBLIC_ID, request);
+    }
+
+    @Test
+    @DisplayName("WebSocket 답변 제출 메시지는 지원자 publicId와 세션 UUID를 서비스에 전달한다")
+    void submitAnswer_ReturnsServiceResponse() {
+        UUID sessionId = UUID.randomUUID();
+        InterviewAnswerSubmitRequest request = new InterviewAnswerSubmitRequest("S_01_00", 1, "답변");
+        InterviewWebSocketMessageResponse serviceResponse =
+                InterviewWebSocketMessageResponse.answerAccepted(sessionId);
+
+        given(interviewFlowService.submitAnswer(sessionId, APPLICANT_PUBLIC_ID, request))
+                .willReturn(serviceResponse);
+
+        InterviewWebSocketMessageResponse response = controller.submitAnswer(sessionId, request, principal());
+
+        assertThat(response).isSameAs(serviceResponse);
+        verify(interviewFlowService).submitAnswer(sessionId, APPLICANT_PUBLIC_ID, request);
+    }
+
+    private Principal principal() {
+        return () -> APPLICANT_PUBLIC_ID;
+    }
+}


### PR DESCRIPTION
## 📝 PR 설명
AI 면접 진행 방식을 STOMP WebSocket 기반으로 구현했습니다.
클라이언트는 WebSocket으로 면접 시작/답변 제출 메시지를 보내고, 서버는 RabbitMQ로 AI 서버와 비동기 연동한 뒤 질문 생성/상태 변경 결과를 `/user/queue/interviews`로 push합니다.

## 📝 Summary
- STOMP WebSocket endpoint(`/ws`, `/ws-sockjs`) 및 메시지 브로커 설정 추가
- STOMP CONNECT 시 JWT 기반 인증 처리 추가
- 면접 시작/답변 제출 WebSocket message controller 추가
- RabbitMQ 기반 질문 생성, transcript 저장, report 생성 이벤트 플로우 구현
- `interview_session_id` 기준 질문 중복 append 방지 및 답변 overwrite 처리
- `interview_session_id` 기준 `DetailAnalysisReport` upsert 처리

## 🙏 Question & PR point

## 📬 Postman

## 📣 Related Issue
- close #77 

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time WebSocket support for interactive AI-driven interviews with live status updates
  * Implemented interview session creation and applicant answer submission capabilities
  * Added real-time question delivery and dynamic transcript management during interview execution
  * Enhanced analysis reporting with detailed skill and culture evaluation data persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->