### PR TITLE
[FIX] 면접 WebSocket 공개 메시지 타입 정리

### DIFF
--- a/src/main/java/com/weiver/interview/dto/response/InterviewWebSocketMessageResponse.java
+++ b/src/main/java/com/weiver/interview/dto/response/InterviewWebSocketMessageResponse.java
@@ -60,20 +60,15 @@ public record InterviewWebSocketMessageResponse(
         );
     }
 
-    public static InterviewWebSocketMessageResponse statusChanged(
-            String type,
-            UUID interviewSessionId,
-            InterviewSessionStatus status,
-            String message
-    ) {
+    public static InterviewWebSocketMessageResponse interviewFinished(UUID interviewSessionId) {
         return new InterviewWebSocketMessageResponse(
-                type,
+                "INTERVIEW_FINISHED",
                 interviewSessionId,
-                status.name(),
+                InterviewSessionStatus.FINISHED.name(),
                 null,
                 null,
                 null,
-                message
+                "면접이 종료되었습니다."
         );
     }
 }

--- a/src/main/java/com/weiver/interview/service/InterviewFlowService.java
+++ b/src/main/java/com/weiver/interview/service/InterviewFlowService.java
@@ -136,12 +136,7 @@ public class InterviewFlowService {
             session.updateStatus(InterviewSessionStatus.TRANSCRIPT_SAVE_REQUESTED);
             sendInterviewMessage(
                     session,
-                    InterviewWebSocketMessageResponse.statusChanged(
-                            "TRANSCRIPT_SAVE_REQUESTED",
-                            session.getInterviewSessionId(),
-                            session.getSessionStatus(),
-                            "면접이 종료되어 transcript 저장을 요청했습니다."
-                    )
+                    InterviewWebSocketMessageResponse.interviewFinished(session.getInterviewSessionId())
             );
             return;
         }
@@ -179,15 +174,6 @@ public class InterviewFlowService {
         session.updateStatus(InterviewSessionStatus.TRANSCRIPT_SAVED);
         publishReportRequested(session);
         session.updateStatus(InterviewSessionStatus.REPORT_REQUESTED);
-        sendInterviewMessage(
-                session,
-                InterviewWebSocketMessageResponse.statusChanged(
-                        "REPORT_REQUESTED",
-                        session.getInterviewSessionId(),
-                        session.getSessionStatus(),
-                        "transcript 저장이 완료되어 최종 리포트 생성을 요청했습니다."
-                )
-        );
     }
 
     /**
@@ -220,15 +206,6 @@ public class InterviewFlowService {
                 );
 
         session.updateStatus(InterviewSessionStatus.REPORT_COMPLETED);
-        sendInterviewMessage(
-                session,
-                InterviewWebSocketMessageResponse.statusChanged(
-                        "REPORT_COMPLETED",
-                        session.getInterviewSessionId(),
-                        session.getSessionStatus(),
-                        "최종 리포트 생성이 완료되었습니다."
-                )
-        );
     }
 
     /**

--- a/src/test/java/com/weiver/interview/service/InterviewFlowServiceTest.java
+++ b/src/test/java/com/weiver/interview/service/InterviewFlowServiceTest.java
@@ -16,6 +16,7 @@ import com.weiver.interview.dto.request.InterviewAnswerSubmitRequest;
 import com.weiver.interview.dto.request.InterviewStartRequest;
 import com.weiver.interview.dto.response.InterviewStartResponse;
 import com.weiver.interview.dto.response.InterviewTurnDTO;
+import com.weiver.interview.dto.response.InterviewWebSocketMessageResponse;
 import com.weiver.interview.event.dto.InterviewQuestionGeneratedData;
 import com.weiver.interview.event.dto.InterviewQuestionRequestedData;
 import com.weiver.interview.event.dto.InterviewReportCompletedData;
@@ -40,6 +41,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -221,7 +223,7 @@ class InterviewFlowServiceTest {
     }
 
     @Test
-    @DisplayName("E_ 질문이 생성되면 면접을 종료하고 transcript 저장 요청 이벤트를 발행한다")
+    @DisplayName("E_ 질문이 생성되면 면접 종료 메시지를 보내고 transcript 저장 요청 이벤트를 발행한다")
     void handleQuestionGenerated_PublishesTranscriptSaveRequestForEndQuestion() {
         Applicant applicant = applicant();
         UUID sessionId = UUID.randomUUID();
@@ -255,6 +257,19 @@ class InterviewFlowServiceTest {
         assertThat(data.skillInterview().turns().get(0).answer()).isEqualTo("기술 답변");
         assertThat(data.cultureInterview().turns()).hasSize(1);
         assertThat(data.cultureInterview().turns().get(0).question()).isEqualTo("컬처 질문");
+
+        ArgumentCaptor<InterviewWebSocketMessageResponse> messageCaptor =
+                ArgumentCaptor.forClass(InterviewWebSocketMessageResponse.class);
+        verify(messagingTemplate).convertAndSendToUser(
+                eq(APPLICANT_PUBLIC_ID),
+                eq("/queue/interviews"),
+                messageCaptor.capture()
+        );
+
+        InterviewWebSocketMessageResponse message = messageCaptor.getValue();
+        assertThat(message.type()).isEqualTo("INTERVIEW_FINISHED");
+        assertThat(message.status()).isEqualTo(InterviewSessionStatus.FINISHED.name());
+        assertThat(message.interviewSessionId()).isEqualTo(sessionId);
     }
 
     @Test
@@ -275,6 +290,7 @@ class InterviewFlowServiceTest {
 
         EventEnvelope<?> envelope = eventCaptor.getValue();
         assertThat(envelope.eventType()).isEqualTo(EventType.INTERVIEW_REPORT_REQUESTED);
+        verifyNoInteractions(messagingTemplate);
     }
 
     @Test
@@ -326,6 +342,7 @@ class InterviewFlowServiceTest {
         assertThat(saved.getSkillAnalysis()).isEqualTo(skillAnalysis);
         assertThat(saved.getCultureAnalysis()).isEqualTo(cultureAnalysis);
         assertThat(session.getSessionStatus()).isEqualTo(InterviewSessionStatus.REPORT_COMPLETED);
+        verifyNoInteractions(messagingTemplate);
     }
 
     @Test
@@ -358,6 +375,7 @@ class InterviewFlowServiceTest {
         verify(detailAnalysisReportRepository, never()).save(any());
         assertThat(existing.getSkillAnalysis()).isEqualTo(evaluation);
         assertThat(existing.getCultureAnalysis()).isEmpty();
+        verifyNoInteractions(messagingTemplate);
     }
 
     @Test


### PR DESCRIPTION
## 📝 PR 설명
면접 WebSocket에서 프론트엔드가 직접 관여하지 않는 내부 처리 상태 메시지를 공개 이벤트에서 제거했습니다. 면접 종료 시 프론트엔드에는 `INTERVIEW_FINISHED`만 전달하고, transcript 저장 요청 및 report 생성/완료 흐름은 기존처럼 백엔드 내부 RabbitMQ 이벤트로 자동 진행되도록 유지했습니다.

## 📝 Summary
- `TRANSCRIPT_SAVE_REQUESTED`, `REPORT_REQUESTED`, `REPORT_COMPLETED` WebSocket push 제거
- 면접 종료 시 프론트 공개 메시지 타입을 `INTERVIEW_FINISHED`로 정리
- transcript 저장 및 report 생성 내부 이벤트 흐름은 유지
- report 관련 내부 처리 단계에서 WebSocket 메시지가 발행되지 않도록 테스트 보강
- `INTERVIEW_WEBSOCKET_API.md`의 Message Types 및 상태 전이 문서 갱신

## 🙏 Question & PR point
- 프론트엔드는 면접 종료 시 `INTERVIEW_FINISHED`만 처리하면 됩니다.

## 📬 Postman

## 📣 Related Issue
- close #105

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined interview completion notifications to send precise "interview finished" messages instead of generic status updates.

* **Tests**
  * Enhanced test coverage for WebSocket notification behavior during interview lifecycle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->